### PR TITLE
Add DebuggerStatement to compiler.compileStatement

### DIFF
--- a/compiler_stmt.go
+++ b/compiler_stmt.go
@@ -49,6 +49,7 @@ func (c *compiler) compileStatement(v ast.Statement, needResult bool) {
 		}
 	case *ast.WithStatement:
 		c.compileWithStatement(v, needResult)
+	case *ast.DebuggerStatement:
 	default:
 		panic(fmt.Errorf("Unknown statement type: %T", v))
 	}


### PR DESCRIPTION
Currently, `goja` panics when trying to compile a `debugger` statement.  According to the [spec](http://www.ecma-international.org/ecma-262/6.0/#sec-debugger-statement), a `debugger` statement is a no-op if no debugging facilities are present.  This PR adds an empty `case` statement for `*ast.DebuggerStatement` in `compiler.compileStatement` so that `debugger` statements become no-ops rather than causing the compiler to panic.

Fixes #3