### PR TITLE
compiler: create eval vm lazily

### DIFF
--- a/compiler.go
+++ b/compiler.go
@@ -129,7 +129,6 @@ func newCompiler() *compiler {
 
 	c.newScope()
 	c.scope.dynamic = true
-	c.evalVM = New().vm
 	return c
 }
 

--- a/compiler_expr.go
+++ b/compiler_expr.go
@@ -995,6 +995,9 @@ func (c *compiler) evalConst(expr compiledExpr) (Value, *Exception) {
 	if expr, ok := expr.(*compiledLiteral); ok {
 		return expr.val, nil
 	}
+	if c.evalVM == nil {
+		c.evalVM = New().vm
+	}
 	var savedPrg *Program
 	createdPrg := false
 	if c.evalVM.prg == nil {


### PR DESCRIPTION
In some cases `compiler.evalVM` will not be used at all, thus it's initialization may be postponed.

Benchmarks (equal results omitted):
```
benchmark                   old ns/op      new ns/op      delta
BenchmarkCompile-8          2732180        2518783        -7.81%
BenchmarkGoReflectGet-8     2461           2444           -0.69%
BenchmarkPut-8              47.7           48.1           +0.84%
BenchmarkPutStr-8           42.1           42.5           +0.95%
BenchmarkGet-8              14.5           14.2           -2.07%
BenchmarkArrayGetStr-8      23.0           23.8           +3.48%
BenchmarkArrayGet-8         63.0           62.5           -0.79%
BenchmarkArrayPut-8         17.1           17.2           +0.58%
BenchmarkToUTF8String-8     2.87           2.89           +0.70%
BenchmarkAdd-8              29.9           29.5           -1.34%
BenchmarkAddString-8        257            255            -0.78%
BenchmarkVmNOP2-8           6.09           6.01           -1.31%
BenchmarkVmNOP1-8           37.8           37.1           -1.85%
BenchmarkVmNOP-8            11.2           11.3           +0.89%
BenchmarkVm1-8              47.8           47.7           -0.21%
BenchmarkFib-8              6369867368     6175009895     -3.06%
BenchmarkEmptyLoop-8        14147          13937          -1.48%
BenchmarkVMAdd-8            22.7           23.5           +3.52%

benchmark                   old allocs     new allocs     delta
BenchmarkCompile-8          19662          18548          -5.67%

benchmark                   old bytes     new bytes     delta
BenchmarkCompile-8          1089561       1004613       -7.80%
```
Not impressive, but we see a ишп difference in Cayley benchmarks:
```
benchmark                                     old ns/op     new ns/op     delta
BenchmarkNamePredicate-8                      261923        118779        -54.65%
BenchmarkLargeSetsNoIntersection-8            8579990       8159019       -4.91%
BenchmarkNetAndSpeed-8                        1287894       1104681       -14.23%
BenchmarkKeanuAndNet-8                        798786        699346        -12.45%
BenchmarkKeanuAndSpeed-8                      1051742       906926        -13.77%
BenchmarkKeanuOther-8                         5587661       5359762       -4.08%
BenchmarkKeanuBullockOther-8                  9217982       8997914       -2.39%
BenchmarkSaveBogartPerformances-8             485717        349294        -28.09%

benchmark                                     old allocs     new allocs     delta
BenchmarkNamePredicate-8                      1512           476            -68.52%
BenchmarkLargeSetsNoIntersection-8            41054          40018          -2.52%
BenchmarkNetAndSpeed-8                        7282           6246           -14.23%
BenchmarkKeanuAndNet-8                        5043           4006           -20.56%
BenchmarkKeanuAndSpeed-8                      6081           5045           -17.04%
BenchmarkKeanuOther-8                         24753          23718          -4.18%
BenchmarkKeanuBullockOther-8                  39915          38877          -2.60%
BenchmarkSaveBogartPerformances-8             2520           1483           -41.15%

benchmark                                     old bytes     new bytes     delta
BenchmarkNamePredicate-8                      115923        31931         -72.45%
BenchmarkLargeSetsNoIntersection-8            3681374       3597895       -2.27%
BenchmarkNetAndSpeed-8                        574895        490839        -14.62%
BenchmarkKeanuAndNet-8                        372253        288244        -22.57%
BenchmarkKeanuAndSpeed-8                      471166        387177        -17.83%
BenchmarkKeanuOther-8                         2249745       2166046       -3.72%
BenchmarkKeanuBullockOther-8                  3644516       3560284       -2.31%
BenchmarkSaveBogartPerformances-8             198144        114189        -42.37%
```