### PR TITLE
Test for and fix (*vm).Interrupt data race

### DIFF
--- a/interrupt_test.go
+++ b/interrupt_test.go
@@ -1,0 +1,42 @@
+package goja
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func testInterruptRace(t testing.TB) {
+	var (
+		run       = make(chan struct{})
+		sig       = func() { run <- struct{}{} }
+		wait      = func() { <-run }
+		vm        = New()
+		interrupt = errors.New("test")
+	)
+
+	go func() {
+		defer sig()
+		wait()
+		time.Sleep(time.Millisecond * 10)
+		vm.Interrupt(interrupt)
+	}()
+
+	defer wait()
+	sig()
+
+	_, err := vm.RunString("for(;;) for(var t = Date.now() + 100; Date.now() < t;);")
+	switch err := err.(type) {
+	case *InterruptedError:
+		if v := err.Value(); v != interrupt {
+			t.Errorf("InterruptedError.Value = %#+v; want %#+v", v, interrupt)
+		}
+	default:
+		t.Errorf("RunString() = %#+v; want %v", err, reflect.TypeOf((*InterruptedError)(nil)))
+	}
+}
+
+func TestInterruptRace(t *testing.T) {
+	testInterruptRace(t)
+}

--- a/vm.go
+++ b/vm.go
@@ -6,6 +6,7 @@ import (
 	"math"
 	"strconv"
 	"sync"
+	"sync/atomic"
 )
 
 const (
@@ -111,7 +112,7 @@ type vm struct {
 	stashAllocs int
 	halt        bool
 
-	interrupt     bool
+	interrupt     uint32
 	interruptVal  interface{}
 	interruptLock sync.Mutex
 }
@@ -277,26 +278,30 @@ func (vm *vm) init() {
 
 func (vm *vm) run() {
 	vm.halt = false
-	for !vm.halt && !vm.interrupt {
+	for !vm.halt && !vm.interrupted() {
 		vm.prg.code[vm.pc].exec(vm)
 	}
 
-	if vm.interrupt {
+	if vm.interrupted() {
 		vm.interruptLock.Lock()
 		v := &InterruptedError{
 			iface: vm.interruptVal,
 		}
-		vm.interrupt = false
 		vm.interruptVal = nil
+		atomic.StoreUint32(&vm.interrupt, 0)
 		vm.interruptLock.Unlock()
 		panic(v)
 	}
 }
 
+func (vm *vm) interrupted() bool {
+	return atomic.LoadUint32(&vm.interrupt) != 0
+}
+
 func (vm *vm) Interrupt(v interface{}) {
 	vm.interruptLock.Lock()
 	vm.interruptVal = v
-	vm.interrupt = true
+	atomic.StoreUint32(&vm.interrupt, 1)
 	vm.interruptLock.Unlock()
 }
 


### PR DESCRIPTION
This patch adds a test for a data race under (*vm).Interrupt, where
an interrupt flag (boolean) is set to true inside of a lock but read
outside of a lock. Since the lock is only taken at the end of (*vm).run
to clear the interrupt value and un-set the interrupt flag, it doesn't
make sense to lock for every check on the interrupt flag.

The patch adds an atomic check for whether the interrupt flag is set
stores it only via atomics. The type change to uint32 also ensures that
there are no other uses of the interrupt bool field (since a uint32
isn't ever treated as a bool and vice-versa). The lock remains in place
to serialize setting and clearing the interrupt value.

The difference between this and #14 is that the atomic check for the
interrupt flag has been inlined into the VM's run loop instead of using
a method call to load and return whether it's set.

This is a continuation of pull request #14 and closes issue #16.