### PR TITLE
Example in readme panics.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,12 @@ Basic Example
 -------------
 
 ```go
-vm := New()
+vm := goja.New()
 v, err := vm.RunString("2 + 2")
 if err != nil {
     panic(err)
 }
-if num := v.Export(); num != 4 {
+if num := v.Export().(int64); num != 4 {
     panic(num)
 }
 ```


### PR DESCRIPTION
The example in the readme reaches `panic(num)` because it's trying to compare an `int64` with the default constant type `int`.

Also the call to `New` should use the package name.