### PR TITLE
Fixed conversion of Go float to Value

### DIFF
--- a/runtime.go
+++ b/runtime.go
@@ -941,18 +941,21 @@ func (r *Runtime) ToValue(i interface{}) Value {
 		} else {
 			return floatToValue(float64(i))
 		}
-	case uint64:
-		if i <= math.MaxInt64 {
-			return intToValue(int64(i))
-		} else {
-			return floatToValue(float64(i))
-		}
 	case uint8:
 		return intToValue(int64(i))
 	case uint16:
 		return intToValue(int64(i))
 	case uint32:
 		return intToValue(int64(i))
+	case uint64:
+		if i <= math.MaxInt64 {
+			return intToValue(int64(i))
+		}
+		return floatToValue(float64(i))
+	case float32:
+		return floatToValue(float64(i))
+	case float64:
+		return floatToValue(i)
 	case map[string]interface{}:
 		obj := &Object{runtime: r}
 		m := &objectGoMapSimple{

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -635,6 +635,20 @@ func TestToValueNil(t *testing.T) {
 	}
 }
 
+func TestToValueFloat(t *testing.T) {
+	vm := New()
+	vm.Set("f64", float64(123))
+	vm.Set("f32", float32(321))
+
+	v, err := vm.RunString("f64 === 123 && f32 === 321")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v.Export().(bool) != true {
+		t.Fatalf("StrictEquals for golang float failed")
+	}
+}
+
 func TestJSONEscape(t *testing.T) {
 	const SCRIPT = `
 	var a = "\\+1";


### PR DESCRIPTION
This pull request adds missing ToValue conversions for float32 and float64. They were showing up as objects in JavaScript instead of numbers, causing `===` and `Array.indexOf` to fail in my project.   