### PR TITLE
Handle labeled if statements

### DIFF
--- a/compiler_stmt.go
+++ b/compiler_stmt.go
@@ -2,10 +2,11 @@ package goja
 
 import (
 	"fmt"
+	"strconv"
+
 	"github.com/dop251/goja/ast"
 	"github.com/dop251/goja/file"
 	"github.com/dop251/goja/token"
-	"strconv"
 )
 
 func (c *compiler) compileStatement(v ast.Statement, needResult bool) {
@@ -75,6 +76,8 @@ func (c *compiler) compileLabeledStatement(v *ast.LabelledStatement, needResult 
 		c.compileLabeledDoWhileStatement(s, needResult, label)
 	case *ast.IfStatement:
 		c.compileLabeledIfStatement(s, needResult, label)
+	case *ast.SwitchStatement:
+		c.compileLabeledSwitchStatement(s, needResult, label)
 	default:
 		c.compileStatement(v.Statement, needResult)
 	}
@@ -626,6 +629,16 @@ func (c *compiler) compileWithStatement(v *ast.WithStatement, needResult bool) {
 	c.emit(leaveWith)
 	c.leaveBlock()
 	c.popScope()
+}
+
+func (c *compiler) compileLabeledSwitchStatement(v *ast.SwitchStatement, needResult bool, label string) {
+	c.block = &block{
+		typ:   blockBranch,
+		label: label,
+		outer: c.block,
+	}
+	c.compileSwitchStatement(v, needResult)
+	c.leaveBlock()
 }
 
 func (c *compiler) compileSwitchStatement(v *ast.SwitchStatement, needResult bool) {

--- a/compiler_stmt.go
+++ b/compiler_stmt.go
@@ -73,6 +73,8 @@ func (c *compiler) compileLabeledStatement(v *ast.LabelledStatement, needResult 
 		c.compileLabeledWhileStatement(s, needResult, label)
 	case *ast.DoWhileStatement:
 		c.compileLabeledDoWhileStatement(s, needResult, label)
+	case *ast.IfStatement:
+		c.compileLabeledIfStatement(s, needResult, label)
 	default:
 		c.compileStatement(v.Statement, needResult)
 	}
@@ -477,6 +479,16 @@ func (c *compiler) compileContinue(label *ast.Identifier, idx file.Idx) {
 	} else {
 		c.throwSyntaxError(int(idx)-1, "Undefined label '%s'", label.Name)
 	}
+}
+
+func (c *compiler) compileLabeledIfStatement(v *ast.IfStatement, needResult bool, label string) {
+	c.block = &block{
+		typ:   blockBranch,
+		label: label,
+		outer: c.block,
+	}
+	c.compileIfStatement(v, needResult)
+	c.leaveBlock()
 }
 
 func (c *compiler) compileIfStatement(v *ast.IfStatement, needResult bool) {

--- a/compiler_test.go
+++ b/compiler_test.go
@@ -1,10 +1,11 @@
 package goja
 
 import (
-	"github.com/dop251/goja/parser"
 	"io/ioutil"
 	"os"
 	"testing"
+
+	"github.com/dop251/goja/parser"
 )
 
 func testScript(script string, expectedResult Value, t *testing.T) {
@@ -488,16 +489,15 @@ func TestIfElseRetVal(t *testing.T) {
 	testScript1(SCRIPT, asciiString("passed"), t)
 }
 
-func TestIfElseLabel(t *testing.T) {
+func TestIfLabel(t *testing.T) {
 	const SCRIPT = `
 	var x = 0;
 	abc: if (true) {
-		x = 1;
 		break abc;
 	}
 	`
 
-	testScript1(SCRIPT, intToValue(1), t)
+	testScript1(SCRIPT, intToValue(0), t)
 }
 
 func TestBreakOutOfTry(t *testing.T) {
@@ -1505,6 +1505,18 @@ func TestSwitchNoMatch(t *testing.T) {
 
 	result;
 
+	`
+
+	testScript1(SCRIPT, _undefined, t)
+}
+
+func TestSwitchLabel(t *testing.T) {
+	const SCRIPT = `
+	var x = 0;
+	abc: switch (x) {
+	case 0:
+		break abc;
+	}
 	`
 
 	testScript1(SCRIPT, _undefined, t)

--- a/compiler_test.go
+++ b/compiler_test.go
@@ -488,6 +488,18 @@ func TestIfElseRetVal(t *testing.T) {
 	testScript1(SCRIPT, asciiString("passed"), t)
 }
 
+func TestIfElseLabel(t *testing.T) {
+	const SCRIPT = `
+	var x = 0;
+	abc: if (true) {
+		x = 1;
+		break abc;
+	}
+	`
+
+	testScript1(SCRIPT, intToValue(1), t)
+}
+
 func TestBreakOutOfTry(t *testing.T) {
 	const SCRIPT = `
 	function A() {


### PR DESCRIPTION
Previously, a label applied to an if statement would result in a SyntaxError if break is called with that label. This is contrary to the behavior found in other Javascript environments (e.g. node). A labeled if statement will now add the necessary block in the compiler.

An example found in the wild that uses labeled if statements: https://cdnjs.cloudflare.com/ajax/libs/react-dom/16.2.0/cjs/react-dom-server.browser.production.min.js This change allows said code to now execute.