### PR TITLE
Add support for exposing "object like" types to runtime as JS objects

### DIFF
--- a/object_like.go
+++ b/object_like.go
@@ -196,7 +196,7 @@ func (o *objectObjectLikeSimple) export() interface{} {
 }
 
 func (o *objectObjectLikeSimple) exportType() reflect.Type {
-	return reflectTypeMap
+	return reflect.TypeOf(o.data)
 }
 
 func (o *objectObjectLikeSimple) equal(other objectImpl) bool {

--- a/object_like.go
+++ b/object_like.go
@@ -1,0 +1,225 @@
+package goja
+
+import (
+	"reflect"
+	"strconv"
+)
+
+// ObjectLike defines interface for js object like abstract that can be exposed to js runtime
+type ObjectLike interface {
+	GetObjectValue(key string) (val interface{}, exists bool)
+	SetObjectValue(key string, val interface{})
+	GetObjectKeys() []string
+	GetObjectLength() int
+	DeleteObjectValue(key string)
+}
+
+type objectObjectLikeSimple struct {
+	baseObject
+	data ObjectLike
+}
+
+func (o *objectObjectLikeSimple) init() {
+	o.baseObject.init()
+	o.prototype = o.val.runtime.global.ObjectPrototype
+	o.class = classObject
+	o.extensible = true
+}
+
+func (o *objectObjectLikeSimple) _get(n Value) Value {
+	return o._getStr(n.String())
+}
+
+func (o *objectObjectLikeSimple) _getStr(name string) Value {
+	v, exists := o.data.GetObjectValue(name)
+	if !exists {
+		return nil
+	}
+	return o.val.runtime.ToValue(v)
+}
+
+func (o *objectObjectLikeSimple) get(n Value) Value {
+	return o.getStr(n.String())
+}
+
+func (o *objectObjectLikeSimple) getProp(n Value) Value {
+	return o.getPropStr(n.String())
+}
+
+func (o *objectObjectLikeSimple) getPropStr(name string) Value {
+	if v := o._getStr(name); v != nil {
+		return v
+	}
+	return o.baseObject.getPropStr(name)
+}
+
+func (o *objectObjectLikeSimple) getStr(name string) Value {
+	if v := o._getStr(name); v != nil {
+		return v
+	}
+	return o.baseObject._getStr(name)
+}
+
+func (o *objectObjectLikeSimple) getOwnProp(name string) Value {
+	if v := o._getStr(name); v != nil {
+		return v
+	}
+	return o.baseObject.getOwnProp(name)
+}
+
+func (o *objectObjectLikeSimple) put(n Value, val Value, throw bool) {
+	o.putStr(n.String(), val, throw)
+}
+
+func (o *objectObjectLikeSimple) _hasStr(name string) bool {
+	_, exists := o.data.GetObjectValue(name)
+	return exists
+}
+
+func (o *objectObjectLikeSimple) _has(n Value) bool {
+	return o._hasStr(n.String())
+}
+
+func (o *objectObjectLikeSimple) putStr(name string, val Value, throw bool) {
+	if o.extensible || o._hasStr(name) {
+		o.data.SetObjectValue(name, val.Export())
+	} else {
+		o.val.runtime.typeErrorResult(throw, "Host object is not extensible")
+	}
+}
+
+func (o *objectObjectLikeSimple) hasProperty(n Value) bool {
+	if o._has(n) {
+		return true
+	}
+	return o.baseObject.hasProperty(n)
+}
+
+func (o *objectObjectLikeSimple) hasPropertyStr(name string) bool {
+	if o._hasStr(name) {
+		return true
+	}
+	return o.baseObject.hasOwnPropertyStr(name)
+}
+
+func (o *objectObjectLikeSimple) hasOwnProperty(n Value) bool {
+	return o._has(n)
+}
+
+func (o *objectObjectLikeSimple) hasOwnPropertyStr(name string) bool {
+	return o._hasStr(name)
+}
+
+func (o *objectObjectLikeSimple) _putProp(name string, value Value, writable, enumerable, configurable bool) Value {
+	o.putStr(name, value, false)
+	return value
+}
+
+func (o *objectObjectLikeSimple) defineOwnProperty(name Value, descr propertyDescr, throw bool) bool {
+	if descr.Getter != nil || descr.Setter != nil {
+		o.val.runtime.typeErrorResult(throw, "Host objects do not support accessor properties")
+		return false
+	}
+	o.put(name, descr.Value, throw)
+	return true
+}
+
+/*
+func (o *objectObjectLikeSimple) toPrimitiveNumber() Value {
+	return o.toPrimitiveString()
+}
+
+func (o *objectObjectLikeSimple) toPrimitiveString() Value {
+	return stringObjectObject
+}
+
+func (o *objectObjectLikeSimple) toPrimitive() Value {
+	return o.toPrimitiveString()
+}
+
+func (o *objectObjectLikeSimple) assertCallable() (call func(FunctionCall) Value, ok bool) {
+	return nil, false
+}
+*/
+
+func (o *objectObjectLikeSimple) deleteStr(name string, throw bool) bool {
+	o.data.DeleteObjectValue(name)
+	return true
+}
+
+func (o *objectObjectLikeSimple) delete(name Value, throw bool) bool {
+	return o.deleteStr(name.String(), throw)
+}
+
+type objectLikePropIter struct {
+	o         *objectObjectLikeSimple
+	propNames []string
+	recursive bool
+	idx       int
+}
+
+func (i *objectLikePropIter) next() (propIterItem, iterNextFunc) {
+	for i.idx < len(i.propNames) {
+		name := i.propNames[i.idx]
+		i.idx++
+		if _, exists := i.o.data.GetObjectValue(name); exists {
+			return propIterItem{name: name, enumerable: _ENUM_TRUE}, i.next
+		}
+	}
+
+	if i.recursive {
+		return i.o.prototype.self._enumerate(true)()
+	}
+
+	return propIterItem{}, nil
+}
+
+func (o *objectObjectLikeSimple) enumerate(all, recursive bool) iterNextFunc {
+	return (&propFilterIter{
+		wrapped: o._enumerate(recursive),
+		all:     all,
+		seen:    make(map[string]bool),
+	}).next
+}
+
+func (o *objectObjectLikeSimple) _enumerate(recursive bool) iterNextFunc {
+	propNames := o.data.GetObjectKeys()
+	return (&objectLikePropIter{
+		o:         o,
+		propNames: propNames,
+		recursive: recursive,
+	}).next
+}
+
+func (o *objectObjectLikeSimple) export() interface{} {
+	return o.data
+}
+
+func (o *objectObjectLikeSimple) exportType() reflect.Type {
+	return reflectTypeMap
+}
+
+func (o *objectObjectLikeSimple) equal(other objectImpl) bool {
+	if other, ok := other.(*objectObjectLikeSimple); ok {
+		return o == other
+	}
+	return false
+}
+
+func (o *objectObjectLikeSimple) sortLen() int64 {
+	return int64(o.data.GetObjectLength())
+}
+
+func (o *objectObjectLikeSimple) sortGet(i int64) Value {
+	return o.getStr(strconv.FormatInt(i, 10))
+}
+
+func (o *objectObjectLikeSimple) swap(i, j int64) {
+	ii := strconv.FormatInt(i, 10)
+	jj := strconv.FormatInt(j, 10)
+	x := o.getStr(ii)
+	y := o.getStr(jj)
+
+	o.putStr(ii, y, false)
+	o.putStr(jj, x, false)
+}

--- a/object_like_test.go
+++ b/object_like_test.go
@@ -1,0 +1,38 @@
+package goja
+
+type mockObjectLikeStruct map[string]interface{}
+
+func (mols mockObjectLikeStruct) GetObjectValue(key string) (val interface{}, exists bool) {
+	if key == "self" {
+		return mols, true
+	}
+
+	val, exists = mols[key]
+	return
+}
+
+func (mols mockObjectLikeStruct) SetObjectValue(key string, val interface{}) {
+	if key == "self" {
+		return
+	}
+
+	mols[key] = val
+}
+
+func (mols mockObjectLikeStruct) GetObjectKeys() []string {
+	keys := make([]string, 1, len(mols)+1)
+	keys[0] = "self"
+	for key := range mols {
+		keys = append(keys, key)
+	}
+
+	return keys
+}
+
+func (mols mockObjectLikeStruct) GetObjectLength() int {
+	return len(mols) + 1
+}
+
+func (mols mockObjectLikeStruct) DeleteObjectValue(key string) {
+	delete(mols, key)
+}

--- a/runtime.go
+++ b/runtime.go
@@ -942,6 +942,18 @@ func (r *Runtime) ToValue(i interface{}) Value {
 	case Value:
 		// TODO: prevent importing Objects from a different runtime
 		return i
+	case ObjectLike:
+		obj := &Object{runtime: r}
+		m := &objectObjectLikeSimple{
+			baseObject: baseObject{
+				val:        obj,
+				extensible: true,
+			},
+			data: i,
+		}
+		obj.self = m
+		m.init()
+		return obj
 	case string:
 		return newStringValue(i)
 	case bool:

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -1044,9 +1044,11 @@ func TestInterruptInWrappedFunction(t *testing.T) {
 
 func TestObjectLike(t *testing.T) {
 	rt := New()
-	rt.Set("obj", mockObjectLikeStruct(map[string]interface{}{
+
+	mockObj := mockObjectLikeStruct(map[string]interface{}{
 		"foo": "bar",
-	}))
+	})
+	rt.Set("obj", mockObj)
 
 	v, err := rt.RunString("obj.foo")
 	if err != nil {
@@ -1085,6 +1087,16 @@ func TestObjectLike(t *testing.T) {
 
 	if v.String() != "self,foo" {
 		t.Error("Wrong object keys returned", v.String())
+	}
+
+	// Test exporting self
+	v, err = rt.RunString("obj.self")
+	if err != nil {
+		t.Error(err)
+	}
+
+	if v.Export().(mockObjectLikeStruct)["foo"] != "biz" {
+		t.Error("Wrong value exported")
 	}
 
 }

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -1042,6 +1042,53 @@ func TestInterruptInWrappedFunction(t *testing.T) {
 	}
 }
 
+func TestObjectLike(t *testing.T) {
+	rt := New()
+	rt.Set("obj", mockObjectLikeStruct(map[string]interface{}{
+		"foo": "bar",
+	}))
+
+	v, err := rt.RunString("obj.foo")
+	if err != nil {
+		t.Error(err)
+	}
+
+	if v.String() != "bar" {
+		t.Error("unexpected value returned", v)
+	}
+
+	// Test "magic" property
+	v, err = rt.RunString("obj.self.foo")
+	if err != nil {
+		t.Error(err)
+	}
+
+	if v.String() != "bar" {
+		t.Error("unexpected value returned", v)
+	}
+
+	// Test setter
+	v, err = rt.RunString("obj.foo = 'biz'; obj.foo")
+	if err != nil {
+		t.Error(err)
+	}
+
+	if v.String() != "biz" {
+		t.Error("unexpected value returned", v)
+	}
+
+	// Test object keys
+	v, err = rt.RunString("Object.keys(obj).join(',')")
+	if err != nil {
+		t.Error(err)
+	}
+
+	if v.String() != "self,foo" {
+		t.Error("Wrong object keys returned", v.String())
+	}
+
+}
+
 /*
 func TestArrayConcatSparse(t *testing.T) {
 function foo(a,b,c)


### PR DESCRIPTION
This functionality is useful for exposing data  on-demand (database, data trough http etc.) to the JS runtime. It essentially allows the key value to be fetched only when it is accessed.  Similar functionality can be found from other JS engines. I can provide more examples or explanation if necessary.
