### PR TITLE
Support for sourcemaps

### DIFF
--- a/ast/node.go
+++ b/ast/node.go
@@ -12,6 +12,7 @@ package ast
 import (
 	"github.com/dop251/goja/file"
 	"github.com/dop251/goja/token"
+	"github.com/go-sourcemap/sourcemap"
 )
 
 // All nodes implement the Node interface.
@@ -383,6 +384,8 @@ type Program struct {
 	DeclarationList []Declaration
 
 	File *file.File
+
+	SourceMap *sourcemap.Consumer
 }
 
 // ==== //

--- a/compiler.go
+++ b/compiler.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	blockLoop = iota
+	blockLoop   = iota
 	blockTry
 	blockBranch
 	blockSwitch
@@ -247,7 +247,7 @@ func (c *compiler) markBlockStart() {
 }
 
 func (c *compiler) compile(in *ast.Program) {
-	c.p.src = NewSrcFile(in.File.Name(), in.File.Source())
+	c.p.src = NewSrcFile(in.File.Name(), in.File.Source(), in.SourceMap)
 
 	if len(in.Body) > 0 {
 		if !c.scope.strict {

--- a/parser/statement.go
+++ b/parser/statement.go
@@ -554,8 +554,7 @@ func (self *_parser) parseProgram() *ast.Program {
 }
 
 func (self *_parser) parseSourceMap() *sourcemap.Consumer {
-	lines := strings.Split(self.str, "\n")
-	lastLine := lines[len(lines)-1]
+	lastLine := self.str[strings.LastIndexByte(self.str, '\n') + 1:]
 	if strings.HasPrefix(lastLine, "//# sourceMappingURL") {
 		urlIndex := strings.Index(lastLine, "=")
 		url := lastLine[urlIndex+1:]

--- a/runtime.go
+++ b/runtime.go
@@ -119,7 +119,7 @@ func (f *stackFrame) write(b *bytes.Buffer) {
 	if f.prg != nil {
 		if n := f.prg.funcName; n != "" {
 			b.WriteString(n)
-			b.WriteString(" (")
+			b.WriteString(" ")
 		}
 		if n := f.prg.src.name; n != "" {
 			b.WriteString(n)
@@ -131,9 +131,6 @@ func (f *stackFrame) write(b *bytes.Buffer) {
 		b.WriteByte('(')
 		b.WriteString(strconv.Itoa(f.pc))
 		b.WriteByte(')')
-		if f.prg.funcName != "" {
-			b.WriteByte(')')
-		}
 	} else {
 		if f.funcName != "" {
 			b.WriteString(f.funcName)

--- a/runtime.go
+++ b/runtime.go
@@ -119,7 +119,7 @@ func (f *stackFrame) write(b *bytes.Buffer) {
 	if f.prg != nil {
 		if n := f.prg.funcName; n != "" {
 			b.WriteString(n)
-			b.WriteString(" ")
+			b.WriteString(" (")
 		}
 		if n := f.prg.src.name; n != "" {
 			b.WriteString(n)
@@ -131,6 +131,9 @@ func (f *stackFrame) write(b *bytes.Buffer) {
 		b.WriteByte('(')
 		b.WriteString(strconv.Itoa(f.pc))
 		b.WriteByte(')')
+		if f.prg.funcName != "" {
+			b.WriteByte(')')
+		}
 	} else {
 		if f.funcName != "" {
 			b.WriteString(f.funcName)

--- a/srcfile.go
+++ b/srcfile.go
@@ -54,8 +54,8 @@ func (f *SrcFile) Position(offset int) Position {
 	}
 
 	return Position{
-		Line: line + 2,
-		Col:  offset - lineStart + 1,
+		Line: row,
+		Col:  col,
 	}
 }
 

--- a/srcfile_test.go
+++ b/srcfile_test.go
@@ -6,7 +6,7 @@ func TestPosition(t *testing.T) {
 	const SRC = `line1
 line2
 line3`
-	f := NewSrcFile("", SRC)
+	f := NewSrcFile("", SRC, nil)
 
 	tests := []struct {
 		offset int


### PR DESCRIPTION
Support to read internal and external (but local) sourcemaps. Remote sourcemaps based on http/https schemes are ignored on purpose.

Errors / exception lines and columns are mapped via the loaded sourcemap and represent the real error location. This is specifically useful when running transpiled (e.g. Typescript) code.