### PR TITLE
Parse constructors using bracket syntax

### DIFF
--- a/parser/expression.go
+++ b/parser/expression.go
@@ -1,7 +1,6 @@
 package parser
 
 import (
-
 	"github.com/dop251/goja/ast"
 	"github.com/dop251/goja/file"
 	"github.com/dop251/goja/token"
@@ -399,6 +398,8 @@ func (self *_parser) parseLeftHandSideExpression() ast.Expression {
 	for {
 		if self.token == token.PERIOD {
 			left = self.parseDotMember(left)
+		} else if self.token == token.LEFT_BRACKET {
+			left = self.parseBracketMember(left)
 		} else if self.token == token.LEFT_BRACE {
 			left = self.parseBracketMember(left)
 		} else {

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -649,6 +649,12 @@ func TestParser(t *testing.T) {
 		test(`new abc()`, nil)
 		test(`new {}`, nil)
 
+		program = test("new module.a()", nil)
+		is(program.Body[0].(*ast.ExpressionStatement).Expression.(*ast.NewExpression).New, 1)
+
+		program = test("new module[\"a\"]()", nil)
+		is(program.Body[0].(*ast.ExpressionStatement).Expression.(*ast.NewExpression).New, 1)
+
 		test(`
             limit = 4
             result = 0


### PR DESCRIPTION
Previously only dot syntax (`new object.name()`) would produce a NewExpression AST element. This change allows the same using bracket syntax (`new object["name"]()`).