### PR TITLE
Runtime.ExportTo() can now export date strings to time.Time targets

### DIFF
--- a/runtime.go
+++ b/runtime.go
@@ -9,6 +9,7 @@ import (
 	"math/rand"
 	"reflect"
 	"strconv"
+	"time"
 
 	"golang.org/x/text/collate"
 
@@ -23,6 +24,7 @@ const (
 var (
 	typeCallable = reflect.TypeOf(Callable(nil))
 	typeValue    = reflect.TypeOf((*Value)(nil)).Elem()
+	typeTime     = reflect.TypeOf(time.Time{})
 )
 
 type global struct {
@@ -1243,6 +1245,14 @@ func (r *Runtime) toReflectValue(v Value, typ reflect.Type) (reflect.Value, erro
 		return reflect.ValueOf(v.Export()), nil
 	} else if et.ConvertibleTo(typ) {
 		return reflect.ValueOf(v.Export()).Convert(typ), nil
+	}
+
+	if typ == typeTime && et.Kind() == reflect.String {
+		time, ok := dateParse(v.String())
+		if !ok {
+			return reflect.Value{}, fmt.Errorf("Could not convert string %v to %v", v, typ)
+		}
+		return reflect.ValueOf(time), nil
 	}
 
 	switch typ.Kind() {

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -589,6 +589,42 @@ func TestRuntime_ExportToStructWithPtrValues(t *testing.T) {
 
 }
 
+func TestRuntime_ExportToTime(t *testing.T) {
+	const SCRIPT = `
+	var dateStr = "2018-08-13T15:02:13+02:00";
+	var str = "test123";
+	`
+
+	vm := New()
+	_, err := vm.RunString(SCRIPT)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var ti time.Time
+	err = vm.ExportTo(vm.Get("dateStr"), &ti)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ti.Format(time.RFC3339) != "2018-08-13T15:02:13+02:00" {
+		t.Fatalf("Unexpected value: '%s'", ti.Format(time.RFC3339))
+	}
+
+	err = vm.ExportTo(vm.Get("str"), &ti)
+	if err == nil {
+		t.Fatal("Expected err to not be nil")
+	}
+
+	var str string
+	err = vm.ExportTo(vm.Get("dateStr"), &str)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if str != "2018-08-13T15:02:13+02:00" {
+		t.Fatalf("Unexpected value: '%s'", str)
+	}
+}
+
 func TestRuntime_ExportToFunc(t *testing.T) {
 	const SCRIPT = `
 	function f(param) {


### PR DESCRIPTION
These changes allow you to export a JavaScript date string into a time.Time target.

The following example shows why this behaviour would be nice to have:
```go
type Model struct {
	ID        uint64
	CreatedAt time.Time
}

test := &Model{
	ID:        1,
	CreatedAt: time.Now(),
}
bytes, _ := json.Marshal(test)

vm := New()
vm.RunString(fmt.Sprintf("var test = JSON.parse( '%s' )", bytes))

test2 := Model{}
err := vm.ExportTo(vm.Get("test"), &test2)
if err != nil {
	t.Fatal(err)
}
if test.CreatedAt.Unix() != test2.CreatedAt.Unix() {
	t.Fatalf("Unexpected value: '%v'", test2.CreatedAt)
}
```

Feel free to close this pull request if you disagree with the changes.