### PR TITLE
Make class name a public field

### DIFF
--- a/builtin_json.go
+++ b/builtin_json.go
@@ -320,7 +320,7 @@ func (ctx *_builtinJSON_stringifyContext) str(key Value, holder *Object) bool {
 				ctx.buf.Write(b)
 				return true
 			} else {
-				switch o1.className() {
+				switch o1.ClassName() {
 				case classNumber:
 					value = o1.toPrimitiveNumber()
 				case classString:

--- a/object.go
+++ b/object.go
@@ -113,7 +113,7 @@ func (o *baseObject) init() {
 	o.values = make(map[string]Value)
 }
 
-func (o *baseObject) className() string {
+func (o *baseObject) ClassName() string {
 	return o.class
 }
 


### PR DESCRIPTION
When handling objects on the Go side, it's convenient to know what kind of `Object` is being used. This is useful, for instance, when trying to make the difference between a plain JS object or a special object like e.g. a `RegExp`