### PR TITLE
Add Object.ToRegExp

### DIFF
--- a/object.go
+++ b/object.go
@@ -1,6 +1,9 @@
 package goja
 
-import "reflect"
+import (
+	"reflect"
+	"regexp"
+)
 
 const (
 	classObject   = "Object"
@@ -48,6 +51,7 @@ type objectImpl interface {
 	toPrimitiveNumber() Value
 	toPrimitiveString() Value
 	toPrimitive() Value
+	toRegexp() *regexp.Regexp
 	assertCallable() (call func(FunctionCall) Value, ok bool)
 	deleteStr(name string, throw bool) bool
 	delete(name Value, throw bool) bool
@@ -468,6 +472,11 @@ func (o *baseObject) toPrimitiveString() Value {
 
 func (o *baseObject) toPrimitive() Value {
 	return o.toPrimitiveNumber()
+}
+
+func (o *baseObject) toRegexp() *regexp.Regexp {
+	o.val.runtime.typeErrorResult(true, "Could not convert %v to regexp", o)
+	return nil
 }
 
 func (o *baseObject) assertCallable() (func(FunctionCall) Value, bool) {

--- a/object_lazy.go
+++ b/object_lazy.go
@@ -1,6 +1,9 @@
 package goja
 
-import "reflect"
+import (
+	"reflect"
+	"regexp"
+)
 
 type lazyObject struct {
 	val    *Object
@@ -107,6 +110,12 @@ func (o *lazyObject) toPrimitive() Value {
 	obj := o.create(o.val)
 	o.val.self = obj
 	return obj.toPrimitive()
+}
+
+func (o *lazyObject) toRegexp() *regexp.Regexp {
+	obj := o.create(o.val)
+	o.val.self = obj
+	return obj.toRegexp()
 }
 
 func (o *lazyObject) assertCallable() (call func(FunctionCall) Value, ok bool) {

--- a/regexp.go
+++ b/regexp.go
@@ -2,10 +2,11 @@ package goja
 
 import (
 	"fmt"
-	"github.com/dlclark/regexp2"
 	"regexp"
 	"unicode/utf16"
 	"unicode/utf8"
+
+	"github.com/dlclark/regexp2"
 )
 
 type regexpPattern interface {
@@ -330,6 +331,10 @@ func (r *regexpObject) execRegexp(target valueString) (match bool, result []int)
 		r.putStr("lastIndex", intToValue(int64(endIndex)), true)
 	}
 	return
+}
+
+func (r *regexpObject) toRegexp() *regexp.Regexp {
+	return regexp.MustCompile(r.source.String())
 }
 
 func (r *regexpObject) exec(target valueString) Value {

--- a/string_ascii.go
+++ b/string_ascii.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"math"
 	"reflect"
+	"regexp"
 	"strconv"
 	"strings"
 )
@@ -135,6 +136,10 @@ func (s asciiString) ToFloat() float64 {
 
 func (s asciiString) ToBoolean() bool {
 	return s != ""
+}
+
+func (s asciiString) ToRegexp() *regexp.Regexp {
+	return nil
 }
 
 func (s asciiString) ToNumber() Value {

--- a/string_unicode.go
+++ b/string_unicode.go
@@ -3,9 +3,6 @@ package goja
 import (
 	"errors"
 	"fmt"
-	"github.com/dop251/goja/parser"
-	"golang.org/x/text/cases"
-	"golang.org/x/text/language"
 	"io"
 	"math"
 	"reflect"
@@ -13,6 +10,10 @@ import (
 	"strings"
 	"unicode/utf16"
 	"unicode/utf8"
+
+	"github.com/dop251/goja/parser"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 type unicodeString []uint16
@@ -90,6 +91,10 @@ func (s unicodeString) ToFloat() float64 {
 
 func (s unicodeString) ToBoolean() bool {
 	return len(s) > 0
+}
+
+func (s unicodeString) ToRegexp() *regexp.Regexp {
+	return nil
 }
 
 func (s unicodeString) toTrimmedUTF8() string {

--- a/value.go
+++ b/value.go
@@ -39,6 +39,7 @@ type Value interface {
 	ToFloat() float64
 	ToNumber() Value
 	ToBoolean() bool
+	ToRegexp() *regexp.Regexp
 	ToObject(*Runtime) *Object
 	SameAs(Value) bool
 	Equals(Value) bool
@@ -124,6 +125,10 @@ func (i valueInt) ToFloat() float64 {
 
 func (i valueInt) ToBoolean() bool {
 	return i != 0
+}
+
+func (i valueInt) ToRegexp() *regexp.Regexp {
+	return nil
 }
 
 func (i valueInt) ToObject(r *Runtime) *Object {
@@ -223,6 +228,10 @@ func (o valueBool) ToFloat() float64 {
 
 func (o valueBool) ToBoolean() bool {
 	return bool(o)
+}
+
+func (o valueBool) ToRegexp() *regexp.Regexp {
+	return nil
 }
 
 func (o valueBool) ToObject(r *Runtime) *Object {
@@ -333,6 +342,10 @@ func (n valueNull) ToBoolean() bool {
 	return false
 }
 
+func (n valueNull) ToRegexp() *regexp.Regexp {
+	return nil
+}
+
 func (n valueNull) ToObject(r *Runtime) *Object {
 	r.typeErrorResult(true, "Cannot convert undefined or null to object")
 	return nil
@@ -403,6 +416,10 @@ func (p *valueProperty) ToFloat() float64 {
 
 func (p *valueProperty) ToBoolean() bool {
 	return false
+}
+
+func (p *valueProperty) ToRegexp() *regexp.Regexp {
+	return nil
 }
 
 func (p *valueProperty) ToObject(r *Runtime) *Object {
@@ -527,6 +544,10 @@ func (f valueFloat) ToBoolean() bool {
 	return float64(f) != 0.0 && !math.IsNaN(float64(f))
 }
 
+func (f valueFloat) ToRegexp() *regexp.Regexp {
+	return nil
+}
+
 func (f valueFloat) ToObject(r *Runtime) *Object {
 	return r.newPrimitiveObject(f, r.global.NumberPrototype, "Number")
 }
@@ -633,6 +654,10 @@ func (o *Object) ToFloat() float64 {
 
 func (o *Object) ToBoolean() bool {
 	return true
+}
+
+func (o *Object) ToRegexp() *regexp.Regexp {
+	return o.self.toRegexp()
 }
 
 func (o *Object) ToObject(r *Runtime) *Object {
@@ -792,6 +817,11 @@ func (o valueUnresolved) ToFloat() float64 {
 func (o valueUnresolved) ToBoolean() bool {
 	o.throw()
 	return false
+}
+
+func (o valueUnresolved) ToRegexp() *regexp.Regexp {
+	o.throw()
+	return nil
 }
 
 func (o valueUnresolved) ToObject(r *Runtime) *Object {


### PR DESCRIPTION
As described in #99, handling RegExp on the golang side is fairly cumbersome. This PR is meant as a first proposal to get the discussion rolling.

The issues I have with this code:

  * Most objects will return `nil` without even reporting an error;
  * `toRegexp` returns the golang `regexp.Regexp` object directly, not a `Value`. I'm wondering if this is acceptable