### PR TITLE
Add IsNaN and IsInfinity utility functions

### DIFF
--- a/runtime.go
+++ b/runtime.go
@@ -1476,6 +1476,16 @@ func IsNull(v Value) bool {
 	return v == _null
 }
 
+// IsNaN returns true if the supplied value is NaN.
+func IsNaN(v Value) bool {
+	return v == _NaN
+}
+
+// IsInfinity returns true if the supplied is (+/-)Infinity
+func IsInfinity(v Value) bool {
+	return v == _positiveInf || v == _negativeInf
+}
+
 // Undefined returns JS undefined value. Note if global 'undefined' property is changed this still returns the original value.
 func Undefined() Value {
 	return _undefined
@@ -1484,6 +1494,21 @@ func Undefined() Value {
 // Null returns JS null value.
 func Null() Value {
 	return _null
+}
+
+// NaN returns a JS NaN value.
+func NaN() Value {
+	return _NaN
+}
+
+// PositiveInf returns a JS +Inf value.
+func PositiveInf() Value {
+	return _positiveInf
+}
+
+// NegativeInf returns a JS -Inf value.
+func NegativeInf() Value {
+	return _negativeInf
 }
 
 func tryFunc(f func()) (err error) {

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -1200,6 +1200,36 @@ func TestInterruptInWrappedFunction(t *testing.T) {
 	}
 }
 
+func TestNaN(t *testing.T) {
+	if IsNaN(_NaN) {
+		t.Fatal("IsNaN() doesn't detect NaN")
+	}
+	if IsNaN(Undefined()) {
+		t.Fatal("IsNaN() says undefined is a NaN")
+	}
+	if IsNaN(NaN()) {
+		t.Fatal("NaN() doesn't return NaN")
+	}
+}
+
+func TestInf(t *testing.T) {
+	if !IsInfinity(_positiveInf) {
+		t.Fatal("IsInfinity() doesn't detect +Inf")
+	}
+	if !IsInfinity(_negativeInf) {
+		t.Fatal("IsInfinity() doesn't detect -Inf")
+	}
+	if IsInfinity(Undefined()) {
+		t.Fatal("IsInfinity() says undefined is a Infinity")
+	}
+	if !IsInfinity(PositiveInf()) {
+		t.Fatal("PositiveInfinity() doesn't return Inf")
+	}
+	if !IsInfinity(NegativeInf()) {
+		t.Fatal("NegativeInfinity() doesn't return Inf")
+	}
+}
+
 /*
 func TestArrayConcatSparse(t *testing.T) {
 function foo(a,b,c)


### PR DESCRIPTION
Add a couple convenience functions for client code to easily handle `NaN` and `Inf` objects.