### PR TITLE
Make class name a public field of Object

### DIFF
--- a/value.go
+++ b/value.go
@@ -765,6 +765,11 @@ func (o *Object) MarshalJSON() ([]byte, error) {
 	return ctx.buf.Bytes(), nil
 }
 
+// ClassName returns the class name
+func (o *Object) ClassName() string {
+	return o.self.className()
+}
+
 func (o valueUnresolved) throw() {
 	o.r.throwReferenceError(o.ref)
 }


### PR DESCRIPTION
Instead of adopting the #100 approach, add a `ClassName` function to `Object`.