### PR TITLE
Add `ExportDepth()` to limit depth of nested fields

### DIFF
--- a/object_lazy.go
+++ b/object_lazy.go
@@ -241,6 +241,12 @@ func (o *lazyObject) export() interface{} {
 	return obj.export()
 }
 
+func (o *lazyObject) exportDepth(depth int) (interface{}, error) {
+	obj := o.create(o.val)
+	o.val.self = obj
+	return obj.exportDepth(depth)
+}
+
 func (o *lazyObject) exportType() reflect.Type {
 	obj := o.create(o.val)
 	o.val.self = obj

--- a/object_test.go
+++ b/object_test.go
@@ -1,6 +1,9 @@
 package goja
 
-import "testing"
+import (
+	"errors"
+	"testing"
+)
 
 func TestArray1(t *testing.T) {
 	r := &Runtime{}
@@ -123,6 +126,17 @@ func TestObjectAssign(t *testing.T) {
         }, b: 2 }).b, 1, "#2");
 	`
 	testScript1(TESTLIB+SCRIPT, _undefined, t)
+}
+
+func TestObjectExportDepth(t *testing.T) {
+	r := New()
+	o := r.NewObject()
+
+	o.DefineDataProperty("o", o, FLAG_TRUE, FLAG_TRUE, FLAG_TRUE)
+	_, err := o.ExportDepth(10)
+	if !errors.Is(err, errNestingTooDeep) {
+		t.Fatalf("Unexpected error: %v", err)
+	}
 }
 
 func BenchmarkPut(b *testing.B) {

--- a/value.go
+++ b/value.go
@@ -724,6 +724,12 @@ func (o *Object) Export() interface{} {
 	return o.self.export()
 }
 
+// ExportDepth exports the object with a maximum depth of nested fields.
+// When exporting an object with a nested field depth beyond the given limit, this method returns an error.
+func (o *Object) ExportDepth(depth int) (interface{}, error) {
+	return o.self.exportDepth(depth)
+}
+
 func (o *Object) ExportType() reflect.Type {
 	return o.self.exportType()
 }


### PR DESCRIPTION
As illustrated in #162, this yields a stack overflow:

```go
func TestObjectExportStackOverflow(t *testing.T) {
	r := New()
	o := r.NewObject()

	o.DefineDataProperty("o", o, FLAG_TRUE, FLAG_TRUE, FLAG_TRUE)
	_ = o.Export()
}
```

To mitigate this, this PR adds `ExportDepth()` which errors when the nesting is too deep.

We can't really change the behavior of `Export()` by using an arbitrary (or runtime configured) limit, because the method doesn't return an error so that would break the library. Panicking could work, as that can be recovered from, contrary to a stack overflow.

An alternative would be to pass around a slice of parents, and as soon as a circular reference is detected, return an error. But this is more versatile as it doesn't only protect against circular references, and is more efficient.