### PR TITLE
Allow objects to be exported to map[string]interface{} in-place

### DIFF
--- a/object_test.go
+++ b/object_test.go
@@ -1,6 +1,7 @@
 package goja
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 )
@@ -152,6 +153,37 @@ func TestExportCircular(t *testing.T) {
 		}
 	} else {
 		t.Fatal("Unexpected type")
+	}
+}
+
+func TestExportInPlace(t *testing.T) {
+	vm := New()
+	o, err := vm.RunString(`var obj = {a: "foo", b: 123}; obj;`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	m := map[string]interface{}{
+		"c": "bar",
+	}
+	addrBefore := fmt.Sprintf("%p", m)
+	err = vm.ExportTo(o, &m)
+	if err != nil {
+		t.Fatal("exporting object into map:", err)
+	}
+	addrAfter := fmt.Sprintf("%p", m)
+
+	if addrBefore != addrAfter {
+		t.Fatal("a new map was created")
+	}
+
+	c, ok := m["c"]
+	if !ok {
+		t.Fatal("element 'c' was discarded during export")
+	}
+
+	if c != "bar" {
+		t.Fatal("element 'c' was modified during export")
 	}
 }
 

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -1625,11 +1625,11 @@ func TestObjSetSym(t *testing.T) {
 	var sym = Symbol(true);
 	var p1 = Object.create(null);
 	var p2 = Object.create(p1);
-	
+
 	Object.defineProperty(p1, sym, {
 	value: 42
 	});
-	
+
 	Object.defineProperty(p2, sym, {
 	value: 43,
 	writable: true,
@@ -1646,11 +1646,11 @@ func TestObjSet(t *testing.T) {
 	'use strict';
 	var p1 = Object.create(null);
 	var p2 = Object.create(p1);
-	
+
 	Object.defineProperty(p1, "test", {
 	value: 42
 	});
-	
+
 	Object.defineProperty(p2, "test", {
 	value: 43,
 	writable: true,


### PR DESCRIPTION
The first commit adds a test-case that currently fails, and the next commit makes this test work.