### PR TITLE
Drop &^ and &^= parsing as AND NOT operator doesn't exist

### DIFF
--- a/parser/expression.go
+++ b/parser/expression.go
@@ -751,8 +751,6 @@ func (self *_parser) parseAssignmentExpression() ast.Expression {
 		operator = token.REMAINDER
 	case token.AND_ASSIGN:
 		operator = token.AND
-	case token.AND_NOT_ASSIGN:
-		operator = token.AND_NOT
 	case token.OR_ASSIGN:
 		operator = token.OR
 	case token.EXCLUSIVE_OR_ASSIGN:

--- a/parser/lexer.go
+++ b/parser/lexer.go
@@ -354,12 +354,7 @@ func (self *_parser) scan() (tkn token.Token, literal string, parsedLiteral unis
 					tkn = token.STRICT_NOT_EQUAL
 				}
 			case '&':
-				if self.chr == '^' {
-					self.read()
-					tkn = self.switch2(token.AND_NOT, token.AND_NOT_ASSIGN)
-				} else {
-					tkn = self.switch3(token.AND, token.AND_ASSIGN, '&', token.LOGICAL_AND)
-				}
+				tkn = self.switch3(token.AND, token.AND_ASSIGN, '&', token.LOGICAL_AND)
 			case '|':
 				tkn = self.switch3(token.OR, token.OR_ASSIGN, '|', token.LOGICAL_OR)
 			case '~':

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -771,6 +771,7 @@ func TestParser(t *testing.T) {
 
 		//// 11.13.1-1-1
 		test("42 = 42;", "(anonymous): Line 1:1 Invalid left-hand side in assignment")
+		test("s &^= 42;", "(anonymous): Line 1:4 Unexpected token ^=")
 
 		// S11.13.2_A4.2_T1.3
 		test(`

--- a/token/token.go
+++ b/token/token.go
@@ -40,7 +40,7 @@ func (tkn Token) precedence(in bool) int {
 	case EXCLUSIVE_OR:
 		return 4
 
-	case AND, AND_ASSIGN, AND_NOT, AND_NOT_ASSIGN:
+	case AND, AND_ASSIGN:
 		return 5
 
 	case EQUAL,

--- a/token/token_const.go
+++ b/token/token_const.go
@@ -26,7 +26,6 @@ const (
 	SHIFT_LEFT           // <<
 	SHIFT_RIGHT          // >>
 	UNSIGNED_SHIFT_RIGHT // >>>
-	AND_NOT              // &^
 
 	ADD_ASSIGN       // +=
 	SUBTRACT_ASSIGN  // -=
@@ -40,7 +39,6 @@ const (
 	SHIFT_LEFT_ASSIGN           // <<=
 	SHIFT_RIGHT_ASSIGN          // >>=
 	UNSIGNED_SHIFT_RIGHT_ASSIGN // >>>=
-	AND_NOT_ASSIGN              // &^=
 
 	LOGICAL_AND // &&
 	LOGICAL_OR  // ||
@@ -133,7 +131,6 @@ var token2string = [...]string{
 	SHIFT_LEFT:                  "<<",
 	SHIFT_RIGHT:                 ">>",
 	UNSIGNED_SHIFT_RIGHT:        ">>>",
-	AND_NOT:                     "&^",
 	ADD_ASSIGN:                  "+=",
 	SUBTRACT_ASSIGN:             "-=",
 	MULTIPLY_ASSIGN:             "*=",
@@ -145,7 +142,6 @@ var token2string = [...]string{
 	SHIFT_LEFT_ASSIGN:           "<<=",
 	SHIFT_RIGHT_ASSIGN:          ">>=",
 	UNSIGNED_SHIFT_RIGHT_ASSIGN: ">>>=",
-	AND_NOT_ASSIGN:              "&^=",
 	LOGICAL_AND:                 "&&",
 	LOGICAL_OR:                  "||",
 	INCREMENT:                   "++",


### PR DESCRIPTION
This actually lead to panics as the parser parsed it but then on
compliation it wasn't supported, but I can't find any reference to those
operators apart from otto so they seem to have never existed.