### PR TITLE
Adding ppc64le architecture support on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ go:
 
 arch:
   - amd64
+  - ppc64le
 #  - s390x
 
 env:
@@ -19,6 +20,10 @@ jobs:
       env: RACE="-race"
     - arch: amd64
       env: RACE=""
+    - arch: ppc64le
+      env: RACE=""
+    - arch: ppc64le
+      env: GIMME_ARCH=386
 
 
 before_install:


### PR DESCRIPTION
Hi,
I had added ppc64le(Linux on Power) architecture support on travis-ci in the PR and looks like its been successfully added. I believe it is ready for the final review and merge. The travis ci build logs can be verified from the link below.
https://travis-ci.com/github/kishorkunal-raj/goja/builds/191370620

Reason behind running tests on ppc64le: This package is included in the ppc64le versions of RHEL and Ubuntu - this allows the top of tree to be tested continuously as it is for Intel, making it easier to catch any possible regressions on ppc64le before the distros begin their clones and builds. This reduces the work in integrating this package into future versions of RHEL/Ubuntu.

Please have a look.

Regards,
Kishor Kunal Raj