### PR TITLE
runtime.ExportTo(): implement custom unmarshaler support

### DIFF
--- a/runtime.go
+++ b/runtime.go
@@ -1946,7 +1946,7 @@ func (r *Runtime) wrapJSFunc(fn Callable, typ reflect.Type) func(args []reflect.
 // Exporting to a value which implements goja.ValueUnmarshaler, calls UnmarshalValue.
 // Exporting to numeric types uses the standard ECMAScript conversion operations, same as used when assigning
 // values to non-clamped typed array items, e.g.
-// https://www.ecma-international.org/ecma-262/10.0/index.html#sec-toint32.
+// https://www.ecma-international.org/ecma-262/10.0/index.html#sec-toint32
 // Returns error if conversion is not possible.
 func (r *Runtime) ExportTo(v Value, target interface{}) error {
 	tval := reflect.ValueOf(target)

--- a/value.go
+++ b/value.go
@@ -42,16 +42,22 @@ var (
 )
 
 var (
-	reflectTypeInt    = reflect.TypeOf(int64(0))
-	reflectTypeBool   = reflect.TypeOf(false)
-	reflectTypeNil    = reflect.TypeOf(nil)
-	reflectTypeFloat  = reflect.TypeOf(float64(0))
-	reflectTypeMap    = reflect.TypeOf(map[string]interface{}{})
-	reflectTypeArray  = reflect.TypeOf([]interface{}{})
-	reflectTypeString = reflect.TypeOf("")
+	reflectTypeInt              = reflect.TypeOf(int64(0))
+	reflectTypeBool             = reflect.TypeOf(false)
+	reflectTypeNil              = reflect.TypeOf(nil)
+	reflectTypeFloat            = reflect.TypeOf(float64(0))
+	reflectTypeMap              = reflect.TypeOf(map[string]interface{}{})
+	reflectTypeArray            = reflect.TypeOf([]interface{}{})
+	reflectTypeString           = reflect.TypeOf("")
+	reflectTypeValueUnmarshaler = reflect.TypeOf((*ValueUnmarshaler)(nil)).Elem()
 )
 
 var intCache [256]Value
+
+// ValueUnmarshaler is the interface implemented by types that can unmarshal a JavaScript value of themselves.
+type ValueUnmarshaler interface {
+	UnmarshalValue(v Value, runtime *Runtime) error
+}
 
 type Value interface {
 	ToInteger() int64


### PR DESCRIPTION
## The Problem

During usage of this library, I stumbled upon some cases when I need to export structs with types which require custom export mechanism.

For example I have User object which has `uuid` string field:

```js
{
  uuid: "4487e60a-e8ef-49f0-95e3-2026930dcda0"
}
```

From Go side, I have struct which has UUID field with type [`uuid.UUID`](https://github.com/google/uuid/blob/master/uuid.go#L19) from `github.com/google/uuid` package.

```go
import "github.com/google/uuid"

struct User {
  UUID *uuid.UUID
}
```

Under the hood, that field has type `[16]byte` which cannot be passed directly to `runtime.Export()`.
I need to parse UUID string and unmarshal it properly.

Most of libraries provide support of custom unmarshaler (like `json.Unmarshaler` from `encoding/json`).
I've added the same feature with this PR.

## Solution

This PR adds option to implement `goja.ValueUnmarshaler` interface to specify export behavior for custom types.

```go
type ValueUnmarshaler interface {
	UnmarshalValue(v Value, runtime *Runtime) error
}
```

**Example:**

```go
type UserID uuid.UUID

func (id *UserID) UnmarshalValue(v Value, vm *goja.Runtime) error {
  str := v.String()
  id.UUID, err = uuid.Parse(str)
  return err
}

struct User {
  UUID *UserID
}
```

Advanced example available in a test case - https://github.com/x1unix/goja/blob/feat/custom-value-unmarshaler/runtime_test.go#L673