### PR TITLE
Run the tc39/test262 in travic CI

### DIFF
--- a/.tc39_test262_checkout.sh
+++ b/.tc39_test262_checkout.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+sha=1ba3a7c4a93fc93b3d0d7e4146f59934a896837d # this is just the commit it was last tested with
+mkdir -p testdata/test262
+cd testdata/test262
+git init
+git remote add origin https://github.com/tc39/test262.git
+git fetch origin --depth=1 "${sha}"
+git reset --hard "${sha}"
+cd -

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,4 +29,5 @@ before_install:
 script:
   - diff -u <(echo -n) <(gofmt -d .)
   - go vet .
+  - bash .tc39_test262_checkout.sh
   - go test -short $RACE ./...


### PR DESCRIPTION
This is a slightly changed version from what was added in https://github.com/loadimpact/k6/pull/1747 to k6. 

I can if desired backport more of the changes including:
- running more of the test and saving how they fail and then compare that the failures don't change or disappear 
- some more filtering, probably not very useful without the above
