### PR TITLE
fix objectGoReflect._toNumber loss of precision

### DIFF
--- a/object_goreflect.go
+++ b/object_goreflect.go
@@ -285,18 +285,72 @@ func (o *objectGoReflect) hasOwnPropertyStr(name unistring.String) bool {
 
 func (o *objectGoReflect) _toNumber() Value {
 	switch o.value.Kind() {
-	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		return intToValue(o.value.Int())
-	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-		return intToValue(int64(o.value.Uint()))
+	case reflect.Int:
+		if v, ok := o.value.Interface().(int); ok {
+			return intToValue(int64(v))
+		}
+		return valueInt(o.value.Int())
+	case reflect.Int8:
+		if v, ok := o.value.Interface().(int8); ok {
+			return intToValue(int64(v))
+		}
+		return valueInt(o.value.Int())
+	case reflect.Int16:
+		if v, ok := o.value.Interface().(int16); ok {
+			return intToValue(int64(v))
+		}
+		return valueInt(o.value.Int())
+	case reflect.Int32:
+		if v, ok := o.value.Interface().(int32); ok {
+			return intToValue(int64(v))
+		}
+		return valueInt(o.value.Int())
+	case reflect.Int64:
+		if v, ok := o.value.Interface().(int64); ok {
+			return intToValue(v)
+		}
+		return valueInt(o.value.Int())
+	case reflect.Uint:
+		if v, ok := o.value.Interface().(uint); ok {
+			return intToValue(int64(v))
+		}
+		return valueInt(o.value.Uint())
+	case reflect.Uint8:
+		if v, ok := o.value.Interface().(uint8); ok {
+			return intToValue(int64(v))
+		}
+		return valueInt(o.value.Uint())
+	case reflect.Uint16:
+		if v, ok := o.value.Interface().(uint16); ok {
+			return intToValue(int64(v))
+		}
+		return valueInt(o.value.Uint())
+	case reflect.Uint32:
+		if v, ok := o.value.Interface().(uint32); ok {
+			return intToValue(int64(v))
+		}
+		return valueInt(o.value.Uint())
+	case reflect.Uint64:
+		if v, ok := o.value.Interface().(uint64); ok {
+			return intToValue(int64(v))
+		}
+		return valueInt(o.value.Uint())
 	case reflect.Bool:
 		if o.value.Bool() {
 			return intToValue(1)
 		} else {
 			return intToValue(0)
 		}
-	case reflect.Float32, reflect.Float64:
-		return floatToValue(o.value.Float())
+	case reflect.Float32:
+		if v, ok := o.value.Interface().(float32); ok {
+			return floatToValue(float64(v))
+		}
+		return valueFloat(o.value.Float())
+	case reflect.Float64:
+		if v, ok := o.value.Interface().(float64); ok {
+			return floatToValue(v)
+		}
+		return valueFloat(o.value.Float())
 	}
 	return nil
 }

--- a/object_goreflect_duration_test.go
+++ b/object_goreflect_duration_test.go
@@ -1,0 +1,29 @@
+package goja_test
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/dop251/goja"
+)
+
+func TestGoReflectDuration(t *testing.T) {
+	vm := goja.New()
+	var expect = time.Duration(math.MaxInt64)
+	vm.Set(`make`, func() time.Duration {
+		return expect
+	})
+	vm.Set(`handle`, func(d time.Duration) {
+		if d.String() != expect.String() {
+			t.Fatal(`expect`, expect, `, but get`, d)
+		}
+	})
+	_, e := vm.RunString(`
+var d=make()
+handle(d)
+`)
+	if e != nil {
+		t.Fatal(e)
+	}
+}


### PR DESCRIPTION
Goja allows to call go functions directly, but passing numbers between go and js may lose precision, because js uses float64 to represent numbers, which should not be regarded as a bug. But types such as time.Duration should not be treated as numbers, at least they should not lose precision when passing between go and js.

These types with Go basic numeric types are usually not processed in js, but multiple Go native functions are called in js to pass them. If the precision is lost, unexpected bugs may occur, and all of this is because objectGoReflect._toNumber narrows the possible value of the number type of reflect.Kind. After obtaining reflect.Kind, it should be judged whether it is a numeric type of type. If so, the value should not be reduced.

The following test The current goja cannot pass because the time.Duration value obtained in the handle of the go function is reduced. This pull request is used to fix such bugs.

```
package goja_test

import (
	"math"
	"testing"
	"time"

	"github.com/dop251/goja"
)

func TestGoReflectDuration(t *testing.T) {
	vm := goja.New()
	var expect = time.Duration(math.MaxInt64)
	vm.Set(`make`, func() time.Duration {
		return expect
	})
	vm.Set(`handle`, func(d time.Duration) {
		if d.String() != expect.String() {
			t.Fatal(`expect`, expect, `, but get`, d)
		}
	})
	_, e := vm.RunString(`
var d=make()
handle(d)
`)
	if e != nil {
		t.Fatal(e)
	}
}
```