### PR TITLE
option CallerFactory

### DIFF
--- a/runtime.go
+++ b/runtime.go
@@ -176,6 +176,8 @@ type Runtime struct {
 	vm    *vm
 	hash  *maphash.Hash
 	idSeq uint64
+
+	opts *options
 }
 
 type StackFrame struct {
@@ -1135,8 +1137,14 @@ func (r *Runtime) toBoolean(b bool) Value {
 
 // New creates an instance of a Javascript runtime that can be used to run code. Multiple instances may be created and
 // used simultaneously, however it is not possible to pass JS values across runtimes.
-func New() *Runtime {
-	r := &Runtime{}
+func New(opt ...Option) *Runtime {
+	opts := defaultOptions
+	for _, o := range opt {
+		o.apply(&opts)
+	}
+	r := &Runtime{
+		opts: &opts,
+	}
 	r.init()
 	return r
 }
@@ -1689,6 +1697,18 @@ func (r *Runtime) ToValue(i interface{}) Value {
 
 func (r *Runtime) wrapReflectFunc(value reflect.Value) func(FunctionCall) Value {
 	return func(call FunctionCall) Value {
+		var (
+			callerFactory = r.opts.callerFactory
+			caller        Caller
+		)
+		if callerFactory != nil {
+			caller = callerFactory.Get()
+			defer callerFactory.Put(caller)
+			if err := caller.Before(&call); err != nil {
+				panic(r.NewGoError(err))
+			}
+		}
+
 		typ := value.Type()
 		nargs := typ.NumIn()
 		var in []reflect.Value
@@ -1747,7 +1767,17 @@ func (r *Runtime) wrapReflectFunc(value reflect.Value) func(FunctionCall) Value 
 			}
 			in[i] = v
 		}
-
+		if caller != nil {
+			out, err := caller.Call(callSlice, value, in)
+			if err != nil {
+				panic(r.NewGoError(err))
+			}
+			result, err := caller.After(out)
+			if err != nil {
+				panic(r.NewGoError(err))
+			}
+			return result
+		}
 		var out []reflect.Value
 		if callSlice {
 			out = value.CallSlice(in)

--- a/runtime_options.go
+++ b/runtime_options.go
@@ -1,0 +1,43 @@
+package goja
+
+import "reflect"
+
+var defaultOptions = options{}
+
+type Option interface {
+	apply(*options)
+}
+type Caller interface {
+	// Before the native function is called, calling Before can be used as an interceptor, and returning errr will panic(r.NewGoError(err))
+	Before(call *FunctionCall) (err error)
+	// Control how to call native functions, for example, you can start a new goroutine to call native functions
+	Call(callSlice bool, callable reflect.Value, in []reflect.Value) (out []reflect.Value, err error)
+	// Called before returning the function call result out to js, used to convert the return value to js or filter the function return value
+	After(out []reflect.Value) (result Value, err error)
+}
+type CallerFactory interface {
+	// Get a Caller
+	Get() Caller
+	// If you want to reuse, you can implement the Put function, otherwise save it as an empty implementation.
+	Put(caller Caller)
+}
+type options struct {
+	callerFactory CallerFactory
+}
+type funcOption struct {
+	f func(*options)
+}
+
+func (fdo *funcOption) apply(do *options) {
+	fdo.f(do)
+}
+func newFuncOption(f func(*options)) *funcOption {
+	return &funcOption{
+		f: f,
+	}
+}
+func WithCallerFactory(callerFactory CallerFactory) Option {
+	return newFuncOption(func(o *options) {
+		o.callerFactory = callerFactory
+	})
+}

--- a/runtime_options_test.go
+++ b/runtime_options_test.go
@@ -1,0 +1,96 @@
+package goja_test
+
+import (
+	"errors"
+	"reflect"
+	"sync"
+	"testing"
+
+	"github.com/dop251/goja"
+)
+
+type caller struct {
+	runtime *goja.Runtime
+}
+
+func (*caller) Before(call *goja.FunctionCall) (err error) {
+	return nil
+}
+
+func (*caller) Call(callSlice bool, callable reflect.Value, in []reflect.Value) (out []reflect.Value, err error) {
+	if callSlice {
+		out = callable.CallSlice(in)
+	} else {
+		out = callable.Call(in)
+	}
+	return
+}
+
+func (c *caller) After(out []reflect.Value) (result goja.Value, err error) {
+	switch len(out) {
+	case 0:
+		result = goja.Undefined()
+	case 1:
+		result = c.runtime.ToValue(out[0].Interface())
+	default:
+		s := make([]interface{}, len(out))
+		for i, v := range out {
+			s[i] = v.Interface()
+		}
+		result = c.runtime.ToValue(s)
+	}
+	return
+}
+
+type callerFactory struct {
+	runtime *goja.Runtime
+	pool    *sync.Pool
+}
+
+func (f *callerFactory) Reset(runtime *goja.Runtime) {
+	f.runtime = runtime
+	f.pool = &sync.Pool{
+		New: func() interface{} {
+			return &caller{
+				runtime: runtime,
+			}
+		},
+	}
+}
+func (f *callerFactory) Get() goja.Caller {
+	return f.pool.Get().(*caller)
+}
+func (f *callerFactory) Put(caller goja.Caller) {
+	f.pool.Put(caller)
+}
+
+func TestOptionCallerFactory(t *testing.T) {
+	factory := &callerFactory{}
+	r := goja.New(goja.WithCallerFactory(factory))
+	factory.Reset(r)
+
+	r.Set(`make`, func(str string) (string, error) {
+		return str, errors.New(str)
+	})
+	r.Set(`checkErr`, func(call goja.FunctionCall) goja.Value {
+		var result bool
+		if e, ok := call.Argument(0).Export().(error); ok {
+			result = e.Error() == call.Argument(1).String()
+		}
+		return r.ToValue(result)
+	})
+	_, e := r.RunString(`
+var s0="cerberus is an idea"
+var [str,e] = make(s0)
+if(str!=s0){
+	throw new Error("not equal")
+}
+if(!checkErr(e,s0)){
+	throw new Error("not error")
+}
+
+`)
+	if e != nil {
+		t.Fatal(e)
+	}
+}


### PR DESCRIPTION
All go native functions in goja are provided by Runtime.wrapReflectFunc with default wrapper calls. Unfortunately, goja does not provide an interface to use a custom implementation instead of the default implementation. 

This pull request solves this problem in a way that is fully compatible with the original API. Now the New function accepts an Option to allow users to customize how to wrap the native go function call.

I think this option is useful because there is no fixed solution that can meet different needs. Providing a modifiable interface is a way to solve the difference in needs. In the default implementation provided by goja, if the last value returned by the go function is error, an exception will be raised in js, so you cannot reasonably call functions such as errors.New() in js, so you should provide a way to use it Can replace the default implementation.

In addition to calling functions like errors.New, after the event mechanism is embedded, you can also use a custom Caller to automatically start a new goroutine to call the go function, and notify js of the result as an event