### PR TITLE
Basic implementation of BigInt, BigInt64Array and BigUint64Array

### DIFF
--- a/ast/node.go
+++ b/ast/node.go
@@ -169,6 +169,12 @@ type (
 		Value   interface{}
 	}
 
+	BigIntLiteral struct {
+		Idx     file.Idx
+		Literal string
+		Value   interface{}
+	}
+
 	ObjectLiteral struct {
 		LeftBrace  file.Idx
 		RightBrace file.Idx
@@ -275,6 +281,7 @@ func (*Identifier) _expressionNode()            {}
 func (*NewExpression) _expressionNode()         {}
 func (*NullLiteral) _expressionNode()           {}
 func (*NumberLiteral) _expressionNode()         {}
+func (*BigIntLiteral) _expressionNode()         {}
 func (*ObjectLiteral) _expressionNode()         {}
 func (*RegExpLiteral) _expressionNode()         {}
 func (*SequenceExpression) _expressionNode()    {}
@@ -567,6 +574,7 @@ func (self *Identifier) Idx0() file.Idx            { return self.Idx }
 func (self *NewExpression) Idx0() file.Idx         { return self.New }
 func (self *NullLiteral) Idx0() file.Idx           { return self.Idx }
 func (self *NumberLiteral) Idx0() file.Idx         { return self.Idx }
+func (self *BigIntLiteral) Idx0() file.Idx         { return self.Idx }
 func (self *ObjectLiteral) Idx0() file.Idx         { return self.LeftBrace }
 func (self *RegExpLiteral) Idx0() file.Idx         { return self.Idx }
 func (self *SequenceExpression) Idx0() file.Idx    { return self.Sequence[0].Idx0() }
@@ -627,6 +635,7 @@ func (self *Identifier) Idx1() file.Idx            { return file.Idx(int(self.Id
 func (self *NewExpression) Idx1() file.Idx         { return self.RightParenthesis + 1 }
 func (self *NullLiteral) Idx1() file.Idx           { return file.Idx(int(self.Idx) + 4) } // "null"
 func (self *NumberLiteral) Idx1() file.Idx         { return file.Idx(int(self.Idx) + len(self.Literal)) }
+func (self *BigIntLiteral) Idx1() file.Idx         { return file.Idx(int(self.Idx) + len(self.Literal)) }
 func (self *ObjectLiteral) Idx1() file.Idx         { return self.RightBrace + 1 }
 func (self *ObjectPattern) Idx1() file.Idx         { return self.RightBrace + 1 }
 func (self *RegExpLiteral) Idx1() file.Idx         { return file.Idx(int(self.Idx) + len(self.Literal)) }

--- a/builtin_bigint.go
+++ b/builtin_bigint.go
@@ -1,0 +1,53 @@
+package goja
+
+func (r *Runtime) bigintproto_valueOf(call FunctionCall) Value {
+	this := call.This
+	if !isBigInt(this) {
+		r.typeErrorResult(true, "Value is not a bigint")
+	}
+	switch t := this.(type) {
+	case valueBigInt:
+		return this
+	case *Object:
+		if v, ok := t.self.(*primitiveValueObject); ok {
+			return v.pValue
+		}
+	}
+
+	panic(r.NewTypeError("BigInt.prototype.valueOf is not generic"))
+}
+
+func isBigInt(v Value) bool {
+	switch t := v.(type) {
+	case valueBigInt:
+		return true
+	case *Object:
+		switch t := t.self.(type) {
+		case *primitiveValueObject:
+			return isBigInt(t.pValue)
+		}
+	}
+	return false
+}
+
+func (r *Runtime) bigintproto_toString(call FunctionCall) Value {
+	this := call.This
+	if !isBigInt(this) {
+		r.typeErrorResult(true, "Value is not a bigint")
+	}
+	b := call.This.ToBigInt()
+	if t, ok := b.(valueBigInt); ok {
+		return asciiString(t.Int.String())
+	}
+	panic(r.NewTypeError("BigInt.prototype.toString is not generic"))
+}
+
+func (r *Runtime) initBigInt() {
+	r.global.BigIntPrototype = r.newPrimitiveObject(valueInt(0), r.global.ObjectPrototype, classBigInt)
+	o := r.global.BigIntPrototype.self
+	o._putProp("toString", r.newNativeFunc(r.bigintproto_toString, nil, "toString", nil, 1), true, false, true)
+	o._putProp("valueOf", r.newNativeFunc(r.bigintproto_valueOf, nil, "valueOf", nil, 0), true, false, true)
+
+	r.global.BigInt = r.newNativeFunc(r.builtin_BigInt, r.builtin_newBigInt, "BigInt", r.global.BigIntPrototype, 1)
+	r.addToGlobal("BigInt", r.global.BigInt)
+}

--- a/builtin_string.go
+++ b/builtin_string.go
@@ -295,7 +295,15 @@ func (r *Runtime) stringproto_indexOf(call FunctionCall) Value {
 	r.checkObjectCoercible(call.This)
 	value := call.This.toString()
 	target := call.Argument(0).toString()
-	pos := call.Argument(1).ToInteger()
+	var pos int64
+	posArg := call.Argument(1)
+	if o, ok := posArg.(*Object); ok {
+		posArg = o.toPrimitiveNumber()
+	}
+	if isBigInt(posArg) {
+		panic(r.NewTypeError("pos must be a number"))
+	}
+	pos = posArg.ToInteger()
 
 	if pos < 0 {
 		pos = 0

--- a/builtin_typedarrays.go
+++ b/builtin_typedarrays.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math"
 	"sort"
+	"strconv"
 	"unsafe"
 
 	"github.com/dop251/goja/unistring"
@@ -458,7 +459,18 @@ func (r *Runtime) typedArrayProto_fill(call FunctionCall) Value {
 			relEnd = l
 		}
 		final := toIntStrict(relToIdx(relEnd, l))
-		value := ta.typedArray.toRaw(call.Argument(0))
+		arg := call.Argument(0)
+		switch ta.typedArray.(type) {
+		case *bigInt64Array, *bigUint64Array:
+			if _, ok := arg.(valueString); !ok {
+				break
+			}
+			_, err := strconv.ParseInt(arg.String(), 0, 64)
+			if err != nil {
+				panic(r.newSyntaxError("cannot convert to bigint", -1))
+			}
+		}
+		value := ta.typedArray.toRaw(arg)
 		ta.viewedArrayBuf.ensureNotDetached(true)
 		for ; k < final; k++ {
 			ta.typedArray.setRaw(ta.offset+k, value)
@@ -895,6 +907,18 @@ func (r *Runtime) typedArrayProto_set(call FunctionCall) Value {
 			for i := 0; i < srcLen; i++ {
 				val := nilSafe(srcObj.self.getIdx(valueInt(i), nil))
 				ta.viewedArrayBuf.ensureNotDetached(true)
+				if _, ok := val.(asciiString); ok {
+					switch ta.typedArray.(type) {
+					case *bigUint64Array:
+						if _, err := strconv.ParseUint(val.String(), 0, 64); err != nil && val.String() != "" {
+	panic(r.newError(r.global.SyntaxError, "cannot convert to bigint"))
+						}
+					case *bigInt64Array:
+						if _, err := strconv.ParseInt(val.String(), 0, 64); err != nil && val.String() != "" {
+	panic(r.newError(r.global.SyntaxError, "cannot convert to bigint"))
+						}
+					}
+				}
 				ta.typedArray.set(targetOffset+i, val)
 			}
 		}
@@ -1239,6 +1263,14 @@ func (r *Runtime) newFloat64Array(args []Value, newTarget *Object) *Object {
 	return r._newTypedArray(args, newTarget, r.newFloat64ArrayObject)
 }
 
+func (r *Runtime) newBigInt64Array(args []Value, newTarget *Object) *Object {
+	return r._newTypedArray(args, newTarget, r.newBigInt64ArrayObject)
+}
+
+func (r *Runtime) newBigUint64Array(args []Value, newTarget *Object) *Object {
+	return r._newTypedArray(args, newTarget, r.newBigUint64ArrayObject)
+}
+
 func (r *Runtime) createArrayBufferProto(val *Object) objectImpl {
 	b := newBaseObjectObj(val, r.global.ObjectPrototype, classObject)
 	byteLengthProp := &valueProperty{
@@ -1431,4 +1463,10 @@ func (r *Runtime) initTypedArrays() {
 
 	r.global.Float64Array = r.newLazyObject(r.typedArrayCreator(r.newFloat64Array, "Float64Array", 8))
 	r.addToGlobal("Float64Array", r.global.Float64Array)
+
+	r.global.BigInt64Array = r.newLazyObject(r.typedArrayCreator(r.newBigInt64Array, "BigInt64Array", 8))
+	r.addToGlobal("BigInt64Array", r.global.BigInt64Array)
+
+	r.global.BigUint64Array = r.newLazyObject(r.typedArrayCreator(r.newBigUint64Array, "BigUint64Array", 8))
+	r.addToGlobal("BigUint64Array", r.global.BigUint64Array)
 }

--- a/destruct.go
+++ b/destruct.go
@@ -158,6 +158,10 @@ func (d *destructKeyedSource) toPrimitiveNumber() Value {
 	return d.w().toPrimitiveNumber()
 }
 
+func (d *destructKeyedSource) toPrimitiveBigInt() Value {
+	return d.w().toPrimitiveBigInt()
+}
+
 func (d *destructKeyedSource) toPrimitiveString() Value {
 	return d.w().toPrimitiveString()
 }

--- a/object.go
+++ b/object.go
@@ -19,6 +19,7 @@ const (
 	classSet      = "Set"
 	classFunction = "Function"
 	classNumber   = "Number"
+	classBigInt   = "BigInt"
 	classString   = "String"
 	classBoolean  = "Boolean"
 	classError    = "Error"
@@ -39,6 +40,7 @@ const (
 var (
 	hintDefault Value = asciiString("default")
 	hintNumber  Value = asciiString("number")
+	hintBigInt  Value = asciiString("bigint")
 	hintString  Value = asciiString("string")
 )
 
@@ -181,6 +183,7 @@ type objectImpl interface {
 	deleteSym(s *Symbol, throw bool) bool
 
 	toPrimitiveNumber() Value
+	toPrimitiveBigInt() Value
 	toPrimitiveString() Value
 	toPrimitive() Value
 	assertCallable() (call func(FunctionCall) Value, ok bool)
@@ -832,6 +835,22 @@ func (o *baseObject) toPrimitiveNumber() Value {
 	return o.val.genericToPrimitiveNumber()
 }
 
+func (o *Object) genericToPrimitiveBigInt() Value {
+	if v := o.tryPrimitive("valueOf"); v != nil {
+		return v
+	}
+
+	if v := o.tryPrimitive("toString"); v != nil {
+		return v
+	}
+
+	panic(o.runtime.NewTypeError("Could not convert %v to primitive", o.self))
+}
+
+func (o *baseObject) toPrimitiveBigInt() Value {
+	return o.val.genericToPrimitiveBigInt()
+}
+
 func (o *Object) genericToPrimitiveString() Value {
 	if v := o.tryPrimitive("toString"); v != nil {
 		return v
@@ -877,6 +896,14 @@ func (o *Object) toPrimitiveNumber() Value {
 	}
 
 	return o.self.toPrimitiveNumber()
+}
+
+func (o *Object) toPrimitiveBigInt() Value {
+	if v := o.tryExoticToPrimitive(hintBigInt); v != nil {
+		return v
+	}
+
+	return o.self.toPrimitiveBigInt()
 }
 
 func (o *Object) toPrimitiveString() Value {

--- a/object_dynamic.go
+++ b/object_dynamic.go
@@ -402,6 +402,10 @@ func (o *baseDynamicObject) toPrimitiveNumber() Value {
 	return o.val.genericToPrimitiveNumber()
 }
 
+func (o *baseDynamicObject) toPrimitiveBigInt() Value {
+	return o.val.genericToPrimitiveBigInt()
+}
+
 func (o *baseDynamicObject) toPrimitiveString() Value {
 	return o.val.genericToPrimitiveString()
 }

--- a/object_lazy.go
+++ b/object_lazy.go
@@ -169,6 +169,12 @@ func (o *lazyObject) toPrimitiveNumber() Value {
 	return obj.toPrimitiveNumber()
 }
 
+func (o *lazyObject) toPrimitiveBigInt() Value {
+	obj := o.create(o.val)
+	o.val.self = obj
+	return obj.toPrimitiveBigInt()
+}
+
 func (o *lazyObject) toPrimitiveString() Value {
 	obj := o.create(o.val)
 	o.val.self = obj

--- a/parser/expression.go
+++ b/parser/expression.go
@@ -68,6 +68,18 @@ func (self *_parser) parsePrimaryExpression() ast.Expression {
 		}
 	case token.NUMBER:
 		self.next()
+		if literal[len(literal)-1] == 'n' {
+			if value, err := parseBigIntLiteral(literal); err != nil {
+				self.error(idx, err.Error())
+				value = 0
+			} else {
+				return &ast.BigIntLiteral{
+					Idx:     idx,
+					Literal: literal,
+					Value:   value,
+				}
+			}
+		}
 		value, err := parseNumberLiteral(literal)
 		if err != nil {
 			self.error(idx, err.Error())
@@ -292,14 +304,27 @@ func (self *_parser) parseObjectPropertyKey() (unistring.String, ast.Expression,
 			Value:   unistring.String(literal),
 		}
 	case token.NUMBER:
-		num, err := parseNumberLiteral(literal)
-		if err != nil {
-			self.error(idx, err.Error())
+		if literal[len(literal)-1] == 'n' {
+			num, err := parseBigIntLiteral(literal)
+			if err != nil {
+				self.error(idx, err.Error())
+			} else {
+				value = &ast.BigIntLiteral{
+					Idx:     idx,
+					Literal: literal,
+					Value:   num,
+				}
+			}
 		} else {
-			value = &ast.NumberLiteral{
-				Idx:     idx,
-				Literal: literal,
-				Value:   num,
+			num, err := parseNumberLiteral(literal)
+			if err != nil {
+				self.error(idx, err.Error())
+			} else {
+				value = &ast.NumberLiteral{
+					Idx:     idx,
+					Literal: literal,
+					Value:   num,
+				}
 			}
 		}
 	case token.STRING:

--- a/parser/lexer_test.go
+++ b/parser/lexer_test.go
@@ -106,6 +106,24 @@ func TestLexer(t *testing.T) {
 			token.EOF, "", 12,
 		)
 
+		test("abc = 1n / 2n",
+			token.IDENTIFIER, "abc", 1,
+			token.ASSIGN, "", 5,
+			token.NUMBER, "1n", 7,
+			token.SLASH, "", 10,
+			token.NUMBER, "2n", 12,
+			token.EOF, "", 14,
+		)
+
+		test("abc = 0x1n / 0x2n",
+			token.IDENTIFIER, "abc", 1,
+			token.ASSIGN, "", 5,
+			token.NUMBER, "0x1n", 7,
+			token.SLASH, "", 12,
+			token.NUMBER, "0x2n", 14,
+			token.EOF, "", 18,
+		)
+
 		test("xyzzy = 'Nothing happens.'",
 			token.IDENTIFIER, "xyzzy", 1,
 			token.ASSIGN, "", 7,

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -992,6 +992,22 @@ func Test_parseNumberLiteral(t *testing.T) {
 	})
 }
 
+func Test_parseBigIntLiteral(t *testing.T) {
+	tt(t, func() {
+		test := func(input string, expect interface{}) {
+			result, err := parseBigIntLiteral(input)
+			is(err, nil)
+			is(result, expect)
+		}
+
+		test("0n", 0)
+
+		test("100n", 100)
+
+		test("0x100n", 0x100)
+	})
+}
+
 func TestPosition(t *testing.T) {
 	tt(t, func() {
 		parser := newParser("", "// Lorem ipsum")

--- a/runtime.go
+++ b/runtime.go
@@ -8,6 +8,7 @@ import (
 	"go/ast"
 	"hash/maphash"
 	"math"
+	"math/big"
 	"math/bits"
 	"math/rand"
 	"reflect"
@@ -53,6 +54,7 @@ type global struct {
 	Function *Object
 	String   *Object
 	Number   *Object
+	BigInt   *Object
 	Boolean  *Object
 	RegExp   *Object
 	Date     *Object
@@ -72,6 +74,8 @@ type global struct {
 	Int32Array        *Object
 	Float32Array      *Object
 	Float64Array      *Object
+	BigInt64Array     *Object
+	BigUint64Array     *Object
 
 	WeakSet *Object
 	WeakMap *Object
@@ -92,6 +96,7 @@ type global struct {
 	ObjectPrototype   *Object
 	ArrayPrototype    *Object
 	NumberPrototype   *Object
+	BigIntPrototype   *Object
 	StringPrototype   *Object
 	BooleanPrototype  *Object
 	FunctionPrototype *Object
@@ -375,6 +380,7 @@ func (r *Runtime) init() {
 	r.initString()
 	r.initGlobalObject()
 	r.initNumber()
+	r.initBigInt()
 	r.initRegExp()
 	r.initDate()
 	r.initBoolean()
@@ -731,6 +737,24 @@ func (r *Runtime) builtin_newNumber(args []Value, proto *Object) *Object {
 	return r.newPrimitiveObject(v, proto, classNumber)
 }
 
+func (r *Runtime) builtin_BigInt(call FunctionCall) Value {
+	if len(call.Arguments) > 0 {
+		return call.Arguments[0].ToBigInt()
+	} else {
+		return valueBigInt{big.NewInt(0)}
+	}
+}
+
+func (r *Runtime) builtin_newBigInt(args []Value, proto *Object) *Object {
+	var v Value
+	if len(args) > 0 {
+		v = args[0].ToBigInt()
+	} else {
+		v = valueBigInt{big.NewInt(0)}
+	}
+	return r.newPrimitiveObject(v, proto, classNumber)
+}
+
 func (r *Runtime) builtin_Boolean(call FunctionCall) Value {
 	if len(call.Arguments) > 0 {
 		if call.Arguments[0].ToBoolean() {
@@ -1029,6 +1053,11 @@ func toInt64(v Value) int64 {
 			return int64(f)
 		}
 	}
+
+	if b, ok := v.(valueBigInt); ok {
+		return b.Int64()
+	}
+
 	return 0
 }
 
@@ -1043,6 +1072,13 @@ func toUint64(v Value) uint64 {
 		if !math.IsNaN(f) && !math.IsInf(f, 0) {
 			return uint64(int64(f))
 		}
+	}
+
+	if b, ok := v.(valueBigInt); ok {
+		if b.Sign() < 0 {
+			return uint64(b.Int64())
+		}
+		return b.Uint64()
 	}
 	return 0
 }

--- a/string_ascii.go
+++ b/string_ascii.go
@@ -5,6 +5,7 @@ import (
 	"hash/maphash"
 	"io"
 	"math"
+	"math/big"
 	"reflect"
 	"strconv"
 	"strings"
@@ -173,6 +174,12 @@ func (s asciiString) ToNumber() Value {
 	}
 
 	return _NaN
+}
+
+func (s asciiString) ToBigInt() Value {
+	b := &big.Int{}
+	b.SetString(string(s), 0)
+	return valueBigInt{b}
 }
 
 func (s asciiString) ToObject(r *Runtime) *Object {

--- a/string_unicode.go
+++ b/string_unicode.go
@@ -6,6 +6,7 @@ import (
 	"hash/maphash"
 	"io"
 	"math"
+	"math/big"
 	"reflect"
 	"strings"
 	"unicode/utf16"
@@ -329,6 +330,12 @@ func (s unicodeString) toTrimmedUTF8() string {
 
 func (s unicodeString) ToNumber() Value {
 	return asciiString(s.toTrimmedUTF8()).ToNumber()
+}
+
+func (s unicodeString) ToBigInt() Value {
+	b := &big.Int{}
+	b.SetString(s.toTrimmedUTF8(), 0)
+	return valueBigInt{b}
 }
 
 func (s unicodeString) ToObject(r *Runtime) *Object {

--- a/tc39_test.go
+++ b/tc39_test.go
@@ -59,23 +59,31 @@ var (
 		"test/language/function-code/each-param-has-own-non-shared-eval-scope.js":     true,
 
 		// These tests are out of date (fixed in https://github.com/tc39/test262/commit/7d998a098e5420cb4b6ee4a05eb8c386d750c596)
-		"test/built-ins/TypedArrayConstructors/internals/DefineOwnProperty/key-is-numericindex.js":                   true,
-		"test/built-ins/TypedArrayConstructors/internals/DefineOwnProperty/key-is-numericindex-desc-configurable.js": true,
+		"test/built-ins/TypedArrayConstructors/internals/DefineOwnProperty/key-is-numericindex.js":                          true,
+		"test/built-ins/TypedArrayConstructors/internals/DefineOwnProperty/BigInt/key-is-numericindex.js":                   true,
+		"test/built-ins/TypedArrayConstructors/internals/DefineOwnProperty/key-is-numericindex-desc-configurable.js":        true,
+		"test/built-ins/TypedArrayConstructors/internals/DefineOwnProperty/BigInt/key-is-numericindex-desc-configurable.js": true,
 
 		// Fixed in https://github.com/tc39/test262/commit/7d998a098e5420cb4b6ee4a05eb8c386d750c596
-		"test/built-ins/TypedArrayConstructors/internals/DefineOwnProperty/detached-buffer.js": true,
+		"test/built-ins/TypedArrayConstructors/internals/DefineOwnProperty/detached-buffer.js":        true,
+		"test/built-ins/TypedArrayConstructors/internals/DefineOwnProperty/BigInt/detached-buffer.js": true,
 		// Fixed in https://github.com/tc39/test262/commit/0bb8fe8aba97765aa3a8d4dd8880cd8e3c238f68
-		"test/built-ins/TypedArrayConstructors/internals/Get/detached-buffer.js":                              true,
-		"test/built-ins/TypedArrayConstructors/internals/DefineOwnProperty/tonumber-value-detached-buffer.js": true,
+		"test/built-ins/TypedArrayConstructors/internals/Get/detached-buffer.js":                                     true,
+		"test/built-ins/TypedArrayConstructors/internals/Get/BigInt/detached-buffer.js":                              true,
+		"test/built-ins/TypedArrayConstructors/internals/DefineOwnProperty/tonumber-value-detached-buffer.js":        true,
+		"test/built-ins/TypedArrayConstructors/internals/DefineOwnProperty/BigInt/tonumber-value-detached-buffer.js": true,
 		// 36c2cd165f93e194b9bcad26e69e8571b1d0e6ed
 		"test/built-ins/ArrayBuffer/prototype/byteLength/detached-buffer.js": true,
 
 		// 96aff62fb25cf9ef27929a8ab822ee853d99b06e
-		"test/built-ins/TypedArrayConstructors/internals/Set/tonumber-value-detached-buffer.js": true,
-		"test/built-ins/TypedArrayConstructors/internals/Set/key-is-out-of-bounds.js":           true,
+		"test/built-ins/TypedArrayConstructors/internals/Set/tonumber-value-detached-buffer.js":        true,
+		"test/built-ins/TypedArrayConstructors/internals/Set/BigInt/tonumber-value-detached-buffer.js": true,
+		"test/built-ins/TypedArrayConstructors/internals/Set/key-is-out-of-bounds.js":                  true,
+		"test/built-ins/TypedArrayConstructors/internals/Set/BigInt/key-is-out-of-bounds.js":           true,
 
 		// 167e596a649ede35df11d03cb3c093941c9cf396
-		"test/built-ins/TypedArrayConstructors/internals/Set/detached-buffer.js": true,
+		"test/built-ins/TypedArrayConstructors/internals/Set/detached-buffer.js":        true,
+		"test/built-ins/TypedArrayConstructors/internals/Set/BigInt/detached-buffer.js": true,
 
 		// Anonymous function name property (now always present)
 		"test/language/expressions/function/name.js":                         true,
@@ -298,13 +306,17 @@ var (
 		"test/built-ins/Array/prototype/splice/create-species-length-exceeding-integer-limit.js":  true,
 		"test/built-ins/Array/prototype/slice/length-exceeding-integer-limit-proxied-array.js":    true,
 
+		// multiplicative order of evaluation
+		"test/language/expressions/multiplication/order-of-evaluation.js": true,
+		"test/language/expressions/division/order-of-evaluation.js": true,
+		"test/language/expressions/modulus/order-of-evaluation.js": true,
+
 		// generators
 		"test/annexB/built-ins/RegExp/RegExp-control-escape-russian-letter.js": true,
 	}
 
 	featuresBlackList = []string{
 		"async-iteration",
-		"BigInt",
 		"class",
 		"generators",
 		"String.prototype.replaceAll",
@@ -370,6 +382,7 @@ var (
 
 	esIdPrefixWhiteList = []string{
 		"sec-addition-*",
+		"sec-multiplicative-*",
 		"sec-array",
 		"sec-%typedarray%",
 		"sec-%typedarray%-of",
@@ -380,6 +393,8 @@ var (
 		"sec-json",
 		"sec-number",
 		"sec-math",
+		"sec-postfix-*",
+		"sec-prefix-*",
 		"sec-arraybuffer-length",
 		"sec-arraybuffer",
 		"sec-regexp",

--- a/vm.go
+++ b/vm.go
@@ -3,6 +3,7 @@ package goja
 import (
 	"fmt"
 	"math"
+	"math/big"
 	"runtime"
 	"strconv"
 	"strings"
@@ -212,6 +213,14 @@ func assertInt64(v Value) (int64, bool) {
 		}
 	}
 	return 0, false
+}
+
+func assertBigInt(v Value) (*big.Int, bool) {
+	num := v.ToNumber()
+	if b, ok := num.(valueBigInt); ok {
+		return b.Int, true
+	}
+	return big.NewInt(0), false
 }
 
 func toIntIgnoreNegZero(v Value) (int64, bool) {
@@ -897,6 +906,16 @@ func (_add) exec(vm *vm) {
 			rightString = right.toString()
 		}
 		ret = leftString.concat(rightString)
+	} else if leftBigInt, ok := left.(valueBigInt); ok {
+		rightBigInt, ok := right.(valueBigInt)
+		if !ok {
+			panic(vm.r.NewTypeError("Cannot add BigInt to other type"))
+		}
+		b := &big.Int{}
+		b.Add(leftBigInt.Int, rightBigInt.Int)
+		ret = valueBigInt{b}
+	} else if _, ok := right.(valueBigInt); ok {
+		panic(vm.r.NewTypeError("Cannot add BigInt to other type"))
 	} else {
 		if leftInt, ok := left.(valueInt); ok {
 			if rightInt, ok := right.(valueInt); ok {
@@ -924,13 +943,21 @@ func (_sub) exec(vm *vm) {
 
 	var result Value
 
-	if left, ok := left.(valueInt); ok {
-		if right, ok := right.(valueInt); ok {
-			result = intToValue(int64(left) - int64(right))
+	if leftInt, ok := left.(valueInt); ok {
+		if rightInt, ok := right.(valueInt); ok {
+			result = intToValue(int64(leftInt) - int64(rightInt))
 			goto end
 		}
+	} else if leftBigInt, ok := left.(valueBigInt); ok {
+		if rightBigInt, ok := right.(valueBigInt); ok {
+			b := &big.Int{}
+			b.Sub(leftBigInt.Int, rightBigInt.Int)
+			result = valueBigInt{b}
+			goto end
+		}
+	} else if _, ok := right.(valueBigInt); ok {
+		panic(vm.r.NewTypeError("Cannot subtract BigInt from other type"))
 	}
-
 	result = floatToValue(left.ToFloat() - right.ToFloat())
 end:
 	vm.sp--
@@ -946,8 +973,28 @@ func (_mul) exec(vm *vm) {
 	left := vm.stack[vm.sp-2]
 	right := vm.stack[vm.sp-1]
 
+	if o, ok := left.(*Object); ok {
+		left = o.toPrimitive()
+	}
+
+	if o, ok := right.(*Object); ok {
+		right = o.toPrimitive()
+	}
+
 	var result Value
 
+	if leftBigInt, ok := left.(valueBigInt); ok {
+		if rightBigInt, ok := right.(valueBigInt); ok {
+			b := &big.Int{}
+			b.Mul(leftBigInt.Int, rightBigInt.Int)
+			result = valueBigInt{b}
+			goto end
+		} else {
+			panic(vm.r.NewTypeError("Cannot multiply BigInt with other type"))
+		}
+	} else if _, ok := right.(valueBigInt); ok {
+		panic(vm.r.NewTypeError("Cannot multiply BigInt with other type"))
+	}
 	if left, ok := assertInt64(left); ok {
 		if right, ok := assertInt64(right); ok {
 			if left == 0 && right == -1 || left == -1 && right == 0 {
@@ -977,26 +1024,55 @@ type _div struct{}
 var div _div
 
 func (_div) exec(vm *vm) {
-	left := vm.stack[vm.sp-2].ToFloat()
-	right := vm.stack[vm.sp-1].ToFloat()
+	left := vm.stack[vm.sp-2]
+	right := vm.stack[vm.sp-1]
+
+	if o, ok := left.(*Object); ok {
+		left = o.toPrimitive()
+	}
+
+	if o, ok := right.(*Object); ok {
+		right = o.toPrimitive()
+	}
 
 	var result Value
+	var rightFloat float64
+	var leftFloat float64
 
-	if math.IsNaN(left) || math.IsNaN(right) {
+	if leftBigInt, ok := left.(valueBigInt); ok {
+		rightBigInt, ok := right.(valueBigInt)
+		if !ok {
+			panic(vm.r.NewTypeError("Cannot divide BigInt by other type"))
+		}
+		if rightBigInt.Int64() == 0 {
+			panic(vm.r.newError(vm.r.global.RangeError, "Cannot divide by zero"))
+		}
+		b := &big.Int{}
+		b.Quo(leftBigInt.Int, rightBigInt.Int)
+		result = valueBigInt{b}
+		goto end
+	} else if _, ok := right.(valueBigInt); ok {
+		panic(vm.r.NewTypeError("Cannot divide BigInt by other type"))
+	}
+
+	leftFloat = left.ToFloat()
+	rightFloat = right.ToFloat()
+
+	if math.IsNaN(leftFloat) || math.IsNaN(rightFloat) {
 		result = _NaN
 		goto end
 	}
-	if math.IsInf(left, 0) && math.IsInf(right, 0) {
+	if math.IsInf(leftFloat, 0) && math.IsInf(rightFloat, 0) {
 		result = _NaN
 		goto end
 	}
-	if left == 0 && right == 0 {
+	if leftFloat == 0 && rightFloat == 0 {
 		result = _NaN
 		goto end
 	}
 
-	if math.IsInf(left, 0) {
-		if math.Signbit(left) == math.Signbit(right) {
+	if math.IsInf(leftFloat, 0) {
+		if math.Signbit(leftFloat) == math.Signbit(rightFloat) {
 			result = _positiveInf
 			goto end
 		} else {
@@ -1004,8 +1080,8 @@ func (_div) exec(vm *vm) {
 			goto end
 		}
 	}
-	if math.IsInf(right, 0) {
-		if math.Signbit(left) == math.Signbit(right) {
+	if math.IsInf(rightFloat, 0) {
+		if math.Signbit(leftFloat) == math.Signbit(rightFloat) {
 			result = _positiveZero
 			goto end
 		} else {
@@ -1013,8 +1089,8 @@ func (_div) exec(vm *vm) {
 			goto end
 		}
 	}
-	if right == 0 {
-		if math.Signbit(left) == math.Signbit(right) {
+	if rightFloat == 0 {
+		if math.Signbit(leftFloat) == math.Signbit(rightFloat) {
 			result = _positiveInf
 			goto end
 		} else {
@@ -1023,7 +1099,7 @@ func (_div) exec(vm *vm) {
 		}
 	}
 
-	result = floatToValue(left / right)
+	result = floatToValue(leftFloat / rightFloat)
 
 end:
 	vm.sp--
@@ -1039,9 +1115,31 @@ func (_mod) exec(vm *vm) {
 	left := vm.stack[vm.sp-2]
 	right := vm.stack[vm.sp-1]
 
+	if o, ok := left.(*Object); ok {
+		left = o.toPrimitive()
+	}
+
+	if o, ok := right.(*Object); ok {
+		right = o.toPrimitive()
+	}
+
 	var result Value
 
-	if leftInt, ok := assertInt64(left); ok {
+	if leftBigInt, ok := left.(valueBigInt); ok {
+		rightBigInt, ok := right.(valueBigInt)
+		if !ok {
+			panic(vm.r.NewTypeError("Cannot get modulus of BigInt with other type"))
+		}
+		if rightBigInt.Int64() == 0 {
+			panic(vm.r.newError(vm.r.global.RangeError, "Cannot divide by zero"))
+		}
+		b := &big.Int{}
+		b.Rem(leftBigInt.Int, rightBigInt.Int)
+		result = valueBigInt{b}
+		goto end
+	} else if _, ok := right.(valueBigInt); ok {
+		panic(vm.r.NewTypeError("Cannot get modulus of BigInt with other type"))
+	} else if leftInt, ok := assertInt64(left); ok {
 		if rightInt, ok := assertInt64(right); ok {
 			if rightInt == 0 {
 				result = _NaN
@@ -1073,7 +1171,11 @@ func (_neg) exec(vm *vm) {
 
 	var result Value
 
-	if i, ok := assertInt64(operand); ok {
+	if b, ok := assertBigInt(operand); ok {
+		nb := &big.Int{}
+		nb.Neg(b)
+		result = valueBigInt{nb}
+	} else if i, ok := assertInt64(operand); ok {
 		if i == 0 {
 			result = _negativeZero
 		} else {
@@ -1110,6 +1212,11 @@ func (_inc) exec(vm *vm) {
 	if i, ok := assertInt64(v); ok {
 		v = intToValue(i + 1)
 		goto end
+	} else if bi, ok := v.(valueBigInt); ok {
+		b := &big.Int{}
+		b.Add(bi.Int, big.NewInt(1))
+		v = valueBigInt{b}
+		goto end
 	}
 
 	v = valueFloat(v.ToFloat() + 1)
@@ -1128,6 +1235,11 @@ func (_dec) exec(vm *vm) {
 
 	if i, ok := assertInt64(v); ok {
 		v = intToValue(i - 1)
+		goto end
+	} else if bi, ok := v.(valueBigInt); ok {
+		b := &big.Int{}
+		b.Sub(bi.Int, big.NewInt(1))
+		v = valueBigInt{b}
 		goto end
 	}
 


### PR DESCRIPTION
Hi!

Here's an implementation for BigInt and Big(U)Int64Array. I thought it could be useful because BigInt cannot be directly translated with Babel but also requires then JSBI. So the numeric token can then be a BigInt. I'm really not 100% sure about this or whether it's better to have a separate token.BIGINT. On the other hand Big(U)Int64Array take 64 bit integers and then there are the arbitrary precision bigints `....n`. (At least it's not much code.) Also in the builtin_typedarrays.go there are now additional switch statements to check input for bigint arrays.

Philip