### PR TITLE
Fix `vm.funcName`

### DIFF
--- a/func.go
+++ b/func.go
@@ -166,6 +166,7 @@ func (f *baseJsFuncObject) _call(call FunctionCall, newTarget, this Value) Value
 	vm.pushCtx()
 	vm.args = len(call.Arguments)
 	vm.prg = f.prg
+	vm.funcName = f.prg.funcName
 	vm.stash = f.stash
 	vm.newTarget = newTarget
 	vm.pc = 0

--- a/runtime.go
+++ b/runtime.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"github.com/dop251/goja/file"
 	"go/ast"
 	"hash/maphash"
 	"math"
@@ -18,6 +17,7 @@ import (
 	"golang.org/x/text/collate"
 
 	js_ast "github.com/dop251/goja/ast"
+	"github.com/dop251/goja/file"
 	"github.com/dop251/goja/parser"
 	"github.com/dop251/goja/unistring"
 )
@@ -823,6 +823,7 @@ func (r *Runtime) eval(srcVal valueString, direct, strict bool, this Value) Valu
 
 	vm.pushCtx()
 	vm.prg = p
+	vm.funcName = p.funcName
 	vm.pc = 0
 	vm.args = 0
 	vm.result = _undefined
@@ -1272,6 +1273,7 @@ func (r *Runtime) RunProgram(p *Program) (result Value, err error) {
 		vm.sb = vm.sp - 1
 	}
 	vm.prg = p
+	vm.funcName = p.funcName
 	vm.pc = 0
 	vm.result = _undefined
 	ex := vm.runTry()
@@ -1287,6 +1289,7 @@ func (r *Runtime) RunProgram(p *Program) (result Value, err error) {
 	} else {
 		vm.stack = nil
 		vm.prg = nil
+		vm.funcName = ""
 		r.leave()
 	}
 	return

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -2082,6 +2082,10 @@ func TestStacktraceLocationThrowFromGo(t *testing.T) {
 	vm.Set("f", f)
 	_, err := vm.RunString(`
 	function main() {
+		(function noop() {})();
+		return callee();
+	}
+	function callee() {
 		return f();
 	}
 	main();
@@ -2090,17 +2094,20 @@ func TestStacktraceLocationThrowFromGo(t *testing.T) {
 		t.Fatal("Expected error")
 	}
 	stack := err.(*Exception).stack
-	if len(stack) != 3 {
+	if len(stack) != 4 {
 		t.Fatalf("Unexpected stack len: %v", stack)
 	}
 	if frame := stack[0]; !strings.HasSuffix(frame.funcName.String(), "TestStacktraceLocationThrowFromGo.func1") {
 		t.Fatalf("Unexpected stack frame 0: %#v", frame)
 	}
-	if frame := stack[1]; frame.funcName != "main" || frame.pc != 1 {
+	if frame := stack[1]; frame.funcName != "callee" || frame.pc != 1 {
 		t.Fatalf("Unexpected stack frame 1: %#v", frame)
 	}
-	if frame := stack[2]; frame.funcName != "" || frame.pc != 3 {
+	if frame := stack[2]; frame.funcName != "main" || frame.pc != 6 {
 		t.Fatalf("Unexpected stack frame 2: %#v", frame)
+	}
+	if frame := stack[3]; frame.funcName != "" || frame.pc != 4 {
+		t.Fatalf("Unexpected stack frame 3: %#v", frame)
 	}
 }
 

--- a/vm.go
+++ b/vm.go
@@ -2612,6 +2612,7 @@ repeat:
 		vm.pushCtx()
 		vm.args = n
 		vm.prg = f.prg
+		vm.funcName = f.prg.funcName
 		vm.stash = f.stash
 		vm.pc = 0
 		vm.stack[vm.sp-n-1], vm.stack[vm.sp-n-2] = vm.stack[vm.sp-n-2], vm.stack[vm.sp-n-1]
@@ -2621,6 +2622,7 @@ repeat:
 		vm.pushCtx()
 		vm.args = n
 		vm.prg = f.prg
+		vm.funcName = f.prg.funcName
 		vm.stash = f.stash
 		vm.pc = 0
 		vm.stack[vm.sp-n-1], vm.stack[vm.sp-n-2] = f.this, vm.stack[vm.sp-n-1]


### PR DESCRIPTION
`vm.funcName` could be dirty in some situations.

For example,

```js
function main() {
	(function noop() {})();
	return callee();
}
function callee() {
	return f();
}
main();
```

When `noop` is returned, `vm.funcName` will be set to "main" by `vm.saveCtx`.

https://github.com/dop251/goja/blob/dc8c55024d06009a0cba080cd738192d368735de/vm.go#L541-L549

However, `vm.funcName` won't be updated when `callee` is called.