### PR TITLE
Error wrapping support for interrupts

### DIFF
--- a/runtime.go
+++ b/runtime.go
@@ -294,9 +294,20 @@ type uncatchableException struct {
 	err error
 }
 
+func (ue *uncatchableException) Unwrap() error {
+	return ue.err
+}
+
 type InterruptedError struct {
 	Exception
 	iface interface{}
+}
+
+func (ue *InterruptedError) Unwrap() error {
+	if err, ok := ue.iface.(error); ok {
+		return err
+	}
+	return nil
 }
 
 type StackOverflowError struct {


### PR DESCRIPTION
When working around the absence of contexts (#243), I noticed that when supply an error to the vm.Interrupt operation, the Golang conventions around error wrapping weren't working, and I couldn't unpick the root type error. 

This PR adds two helper wrapper methods so that when you call interrupt with a Go error, the underlying error returned from the runtime allows people to determine the root Go error involved. This allows you do things like:

```
_, err := vm.Interrupt(io.EOF)
....
require.ErrorIs(t, err, io.EOF, "Should contain io.EOF somewhere in the unwrap chain")
```
