### PR TITLE
Context Support

### DIFF
--- a/runtime.go
+++ b/runtime.go
@@ -403,7 +403,8 @@ func (r *Runtime) init() {
 	r.globalObject = r.NewObject()
 
 	r.vm = &vm{
-		r: r,
+		r:   r,
+		ctx: goctx.TODO(),
 	}
 	r.vm.init()
 


### PR DESCRIPTION
This PR includes support for Go contexts, enabling:

- Timeout based limits on VM execution.
- Extension of native code interop surface to support passing contexts (Constructors, Function calls, including with and without runtime variants). This enables easy integration with remote services, propagation of tracing data, and other data to be passed through the process chain. 
- Context enforcement inside the VM is done without using goroutines, checking the context error state and forcing an interrupt at that point. This yields no meaningfully measurable difference in runtime performance.
- Code without context awareness is unchanged.

Includes test coverage and benchmarks. Note that performance is intrinsically tied into what type of context you're using, as with anything in Go, but the default cases use context.TODO which has effectively a no-op Err() check, meaning there's essentially no performance profile change __unless__ you intentionally use a more meaningful context that needs measurement for completion.