### PR TITLE
Don't run errors through fmt.Sprintf when not necessary

### DIFF
--- a/runtime.go
+++ b/runtime.go
@@ -545,7 +545,7 @@ func (r *Runtime) NewTypeError(args ...interface{}) *Object {
 }
 
 func (r *Runtime) NewGoError(err error) *Object {
-	e := r.newError(r.global.GoError, err.Error()).(*Object)
+	e := r.builtin_new(r.global.GoError, []Value{newStringValue(err.Error())})
 	e.Set("value", err)
 	return e
 }

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -2482,3 +2482,12 @@ func BenchmarkAsciiStringMapGet(b *testing.B) {
 		}
 	}
 }
+
+func TestErrorStrangeSymbols(t *testing.T) {
+	vm := New()
+	vm.Set("a", func() (Value, error) { return nil, errors.New("something %s %f") })
+	_, err := vm.RunString("a()")
+	if !strings.Contains(err.Error(), "something %s %f") {
+		t.Fatalf("Wrong value %q", err.Error())
+	}
+}


### PR DESCRIPTION
fixes #388