### PR TITLE
Support for custom method in js to support logs list

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ v, err := vm.RunString("2 + 2")
 if err != nil {
     panic(err)
 }
-if num := v.Export().(int64); num != 4 {
+if num := v.Result.Export().(int64); num != 4 {
     panic(num)
 }
 ```
@@ -232,7 +232,7 @@ type S struct {
 }
 vm.Set("s", S{Field: 42})
 res, _ := vm.RunString(`s.field`) // without the mapper it would have been s.Field
-fmt.Println(res.Export())
+fmt.Println(res.Result.Export())
 // Output: 42
 ```
 
@@ -270,6 +270,30 @@ if jserr, ok := err.(*Exception); ok {
     }
 } else {
     panic("wrong type")
+}
+```
+
+-------------
+
+Run JavaScript and get the logs returned from the custom `log` method
+
+```go
+vm := goja.New()
+script := `log("Hello world"); 2+2`
+prog, err := goja.Compile("", script, true)
+if err != nil {
+    panic(err)
+}
+response, err := vm.RunProgram(prog)
+if err != nil {
+    panic(err)
+}
+if num := response.Result.Export().(int64); num != 4 {
+    panic(num)
+}
+
+if logs := response.ConsoleLogs; logs[0] != "Hello world" {
+    panic(logs)
 }
 ```
 

--- a/func.go
+++ b/func.go
@@ -180,10 +180,10 @@ func (f *baseJsFuncObject) _call(call FunctionCall, newTarget, this Value) Value
 	pc := vm.pc
 	if pc != -1 {
 		vm.pc++ // fake "return address" so that captureStack() records the correct call location
-		vm.pushCtx()
+		vm.pushCtx(nil, 0)
 		vm.callStack = append(vm.callStack, context{pc: -1}) // extra frame so that run() halts after ret
 	} else {
-		vm.pushCtx()
+		vm.pushCtx(nil, 0)
 	}
 	vm.args = len(call.Arguments)
 	vm.prg = f.prg

--- a/goja/main.go
+++ b/goja/main.go
@@ -34,11 +34,11 @@ func load(vm *goja.Runtime, call goja.FunctionCall) goja.Value {
 	if err != nil {
 		panic(vm.ToValue(fmt.Sprintf("Could not read %s: %v", p, err)))
 	}
-	v, err := vm.RunScript(p, string(b))
+	response, err := vm.RunScript(p, string(b))
 	if err != nil {
 		panic(err)
 	}
-	return v
+	return response.Result
 }
 
 func newRandSource() goja.RandSource {

--- a/test/testPrintLogs.go
+++ b/test/testPrintLogs.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"fmt"
+	"github.com/dop251/goja"
+	"github.com/dop251/goja_nodejs/require"
+)
+
+func ScriptEval() {
+	vm := goja.New()
+	new(require.Registry).Enable(vm)
+	script := `
+		var a = 5;
+		log("Consoling from log method - statement 1")
+		log("Consoling from log method - statement 2")
+		log("Variable value "+ (a+5))
+		a
+	`
+	prog, err := goja.Compile("", script, true)
+	if err != nil {
+		fmt.Printf("Error compiling the script %v ", err)
+		return
+	}
+	fmt.Println("Running ... \n ")
+	response, _ := vm.RunProgram(prog)
+	fmt.Println(response.Result)
+	fmt.Println("---------")
+	fmt.Printf("%v", response.ConsoleLogs)
+}
+
+func main() {
+	ScriptEval()
+}

--- a/value.go
+++ b/value.go
@@ -133,6 +133,11 @@ type valueProperty struct {
 	setterFunc   *Object
 }
 
+type JSEvalResponse struct {
+	Result      Value
+	ConsoleLogs []string
+}
+
 var (
 	errAccessBeforeInit = referenceError("Cannot access a variable before initialization")
 	errAssignToConst    = typeError("Assignment to constant variable.")


### PR DESCRIPTION
This release contains

- Refactored response returned from `RunString` & `RunProgram` methods containing Value and Logs list
```
type JSEvalResponse struct {
	Result      Value
	ConsoleLogs []string
}
```
- updated Readme file 
- testPrintLogs.go file to actually show a running solution to this