### PR TITLE
This object is shared between runtimes

### DIFF
--- a/object.go
+++ b/object.go
@@ -48,6 +48,7 @@ type Object struct {
 	self    objectImpl
 
 	weakRefs map[weakMap]Value
+	share    bool
 }
 
 type iterNextFunc func() (propIterItem, iterNextFunc)

--- a/runtime.go
+++ b/runtime.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"github.com/dop251/goja/file"
 	"go/ast"
 	"hash/maphash"
 	"math"
@@ -14,6 +13,8 @@ import (
 	"runtime"
 	"strconv"
 	"time"
+
+	"github.com/dop251/goja/file"
 
 	"golang.org/x/text/collate"
 
@@ -1719,7 +1720,7 @@ func (r *Runtime) ToValue(i interface{}) Value {
 		if i == nil || i.runtime == nil {
 			return _null
 		}
-		if i.runtime != r {
+		if i.runtime != r && !i.share {
 			panic(r.NewTypeError("Illegal runtime transition of an Object"))
 		}
 		return i

--- a/value.go
+++ b/value.go
@@ -937,6 +937,11 @@ func (o *Object) ClassName() string {
 	return o.self.className()
 }
 
+// Share This object is shared between runtimes
+func (o *Object) Share() {
+	o.share = true
+}
+
 func (o valueUnresolved) throw() {
 	o.r.throwReferenceError(o.ref)
 }


### PR DESCRIPTION
sometimes it is necessary to share the same read-only object that uses a lot of memory between runtimes, providing an optional method