### PR TITLE
Throwing TypeError avoid dependency (*runtime)

### DIFF
--- a/array.go
+++ b/array.go
@@ -353,7 +353,7 @@ func (a *arrayObject) expand(idx uint32) bool {
 			} else {
 				if bits.UintSize == 32 {
 					if targetLen >= math.MaxInt32 {
-						panic(a.val.runtime.NewTypeError("Array index overflows int"))
+						panic(makeTypeError("Array index overflows int"))
 					}
 				}
 				tl := int(targetLen)

--- a/builtin_array.go
+++ b/builtin_array.go
@@ -51,7 +51,7 @@ func arraySpeciesCreate(obj *Object, size int64) *Object {
 					return constructor([]Value{intToValue(size)}, constructObj)
 				}
 			}
-			panic(obj.runtime.NewTypeError("Species is not a constructor"))
+			panic(makeTypeError("Species is not a constructor"))
 		}
 	}
 	return obj.runtime.newArrayLength(size)
@@ -273,7 +273,7 @@ func (r *Runtime) arrayproto_concat_append(a *Object, item Value) {
 	if obj, ok := item.(*Object); ok && isConcatSpreadable(obj) {
 		length := toLength(obj.self.getStr("length", nil))
 		if aLength+length >= maxInt {
-			panic(r.NewTypeError("Invalid array length"))
+			panic(makeTypeError("Invalid array length"))
 		}
 		for i := int64(0); i < length; i++ {
 			v := obj.self.getIdx(valueInt(i), nil)
@@ -348,7 +348,7 @@ func (r *Runtime) arrayproto_sort(call FunctionCall) Value {
 			compareFn, _ = arg.self.assertCallable()
 		}
 		if compareFn == nil {
-			panic(r.NewTypeError("The comparison function must be either a function or undefined"))
+			panic(makeTypeError("The comparison function must be either a function or undefined"))
 		}
 	}
 
@@ -407,7 +407,7 @@ func (r *Runtime) arrayproto_splice(call FunctionCall) Value {
 	itemCount := max(int64(len(call.Arguments)-2), 0)
 	newLength := length - actualDeleteCount + itemCount
 	if newLength >= maxInt {
-		panic(r.NewTypeError("Invalid array length"))
+		panic(makeTypeError("Invalid array length"))
 	}
 	a := arraySpeciesCreate(o, actualDeleteCount)
 	if src := r.checkStdArrayObj(o); src != nil {
@@ -501,7 +501,7 @@ func (r *Runtime) arrayproto_unshift(call FunctionCall) Value {
 	if argCount > 0 {
 		newSize := length + argCount
 		if newSize >= maxInt {
-			panic(r.NewTypeError("Invalid array length"))
+			panic(makeTypeError("Invalid array length"))
 		}
 		if arr := r.checkStdArrayObjWithProto(o); arr != nil && newSize < math.MaxUint32 {
 			if int64(cap(arr.values)) >= newSize {
@@ -1149,7 +1149,7 @@ func (r *Runtime) flattenIntoArray(target, source *Object, sourceLen, start, dep
 				targetIndex = r.flattenIntoArray(target, elementArray, elementLen, targetIndex, depth-1, nil, nil)
 			} else {
 				if targetIndex >= maxInt-1 {
-					panic(r.NewTypeError("Invalid array length"))
+					panic(makeTypeError("Invalid array length"))
 				}
 				createDataPropertyOrThrow(target, intToValue(targetIndex), element)
 				targetIndex++
@@ -1226,7 +1226,7 @@ func (r *Runtime) array_from(call FunctionCall) Value {
 			}
 		}
 		if mapFn == nil {
-			panic(r.NewTypeError("%s is not a function", mapFnArg))
+			panic(makeTypeError("%s is not a function", mapFnArg))
 		}
 	}
 	t := call.Argument(2)
@@ -1345,7 +1345,7 @@ func (r *Runtime) arrayIterProto_next(call FunctionCall) Value {
 	if iter, ok := thisObj.self.(*arrayIterObject); ok {
 		return iter.next()
 	}
-	panic(r.NewTypeError("Method Array Iterator.prototype.next called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: thisObj})))
+	panic(makeTypeError("Method Array Iterator.prototype.next called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: thisObj})))
 }
 
 func (r *Runtime) createArrayProto(val *Object) objectImpl {

--- a/builtin_date.go
+++ b/builtin_date.go
@@ -106,7 +106,7 @@ func (r *Runtime) dateproto_toString(call FunctionCall) Value {
 			return stringInvalidDate
 		}
 	}
-	panic(r.NewTypeError("Method Date.prototype.toString is called on incompatible receiver"))
+	panic(makeTypeError("Method Date.prototype.toString is called on incompatible receiver"))
 }
 
 func (r *Runtime) dateproto_toUTCString(call FunctionCall) Value {
@@ -118,7 +118,7 @@ func (r *Runtime) dateproto_toUTCString(call FunctionCall) Value {
 			return stringInvalidDate
 		}
 	}
-	panic(r.NewTypeError("Method Date.prototype.toUTCString is called on incompatible receiver"))
+	panic(makeTypeError("Method Date.prototype.toUTCString is called on incompatible receiver"))
 }
 
 func (r *Runtime) dateproto_toISOString(call FunctionCall) Value {
@@ -136,7 +136,7 @@ func (r *Runtime) dateproto_toISOString(call FunctionCall) Value {
 			panic(r.newError(r.global.RangeError, "Invalid time value"))
 		}
 	}
-	panic(r.NewTypeError("Method Date.prototype.toISOString is called on incompatible receiver"))
+	panic(makeTypeError("Method Date.prototype.toISOString is called on incompatible receiver"))
 }
 
 func (r *Runtime) dateproto_toJSON(call FunctionCall) Value {
@@ -157,7 +157,7 @@ func (r *Runtime) dateproto_toJSON(call FunctionCall) Value {
 		}
 	}
 
-	panic(r.NewTypeError("toISOString is not a function"))
+	panic(makeTypeError("toISOString is not a function"))
 }
 
 func (r *Runtime) dateproto_toPrimitive(call FunctionCall) Value {
@@ -170,7 +170,7 @@ func (r *Runtime) dateproto_toPrimitive(call FunctionCall) Value {
 	if asciiString("number").StrictEquals(arg) {
 		return o.self.toPrimitiveNumber()
 	}
-	panic(r.NewTypeError("Invalid hint: %s", arg))
+	panic(makeTypeError("Invalid hint: %s", arg))
 }
 
 func (r *Runtime) dateproto_toDateString(call FunctionCall) Value {
@@ -182,7 +182,7 @@ func (r *Runtime) dateproto_toDateString(call FunctionCall) Value {
 			return stringInvalidDate
 		}
 	}
-	panic(r.NewTypeError("Method Date.prototype.toDateString is called on incompatible receiver"))
+	panic(makeTypeError("Method Date.prototype.toDateString is called on incompatible receiver"))
 }
 
 func (r *Runtime) dateproto_toTimeString(call FunctionCall) Value {
@@ -194,7 +194,7 @@ func (r *Runtime) dateproto_toTimeString(call FunctionCall) Value {
 			return stringInvalidDate
 		}
 	}
-	panic(r.NewTypeError("Method Date.prototype.toTimeString is called on incompatible receiver"))
+	panic(makeTypeError("Method Date.prototype.toTimeString is called on incompatible receiver"))
 }
 
 func (r *Runtime) dateproto_toLocaleString(call FunctionCall) Value {
@@ -206,7 +206,7 @@ func (r *Runtime) dateproto_toLocaleString(call FunctionCall) Value {
 			return stringInvalidDate
 		}
 	}
-	panic(r.NewTypeError("Method Date.prototype.toLocaleString is called on incompatible receiver"))
+	panic(makeTypeError("Method Date.prototype.toLocaleString is called on incompatible receiver"))
 }
 
 func (r *Runtime) dateproto_toLocaleDateString(call FunctionCall) Value {
@@ -218,7 +218,7 @@ func (r *Runtime) dateproto_toLocaleDateString(call FunctionCall) Value {
 			return stringInvalidDate
 		}
 	}
-	panic(r.NewTypeError("Method Date.prototype.toLocaleDateString is called on incompatible receiver"))
+	panic(makeTypeError("Method Date.prototype.toLocaleDateString is called on incompatible receiver"))
 }
 
 func (r *Runtime) dateproto_toLocaleTimeString(call FunctionCall) Value {
@@ -230,7 +230,7 @@ func (r *Runtime) dateproto_toLocaleTimeString(call FunctionCall) Value {
 			return stringInvalidDate
 		}
 	}
-	panic(r.NewTypeError("Method Date.prototype.toLocaleTimeString is called on incompatible receiver"))
+	panic(makeTypeError("Method Date.prototype.toLocaleTimeString is called on incompatible receiver"))
 }
 
 func (r *Runtime) dateproto_valueOf(call FunctionCall) Value {
@@ -242,7 +242,7 @@ func (r *Runtime) dateproto_valueOf(call FunctionCall) Value {
 			return _NaN
 		}
 	}
-	panic(r.NewTypeError("Method Date.prototype.valueOf is called on incompatible receiver"))
+	panic(makeTypeError("Method Date.prototype.valueOf is called on incompatible receiver"))
 }
 
 func (r *Runtime) dateproto_getTime(call FunctionCall) Value {
@@ -254,7 +254,7 @@ func (r *Runtime) dateproto_getTime(call FunctionCall) Value {
 			return _NaN
 		}
 	}
-	panic(r.NewTypeError("Method Date.prototype.getTime is called on incompatible receiver"))
+	panic(makeTypeError("Method Date.prototype.getTime is called on incompatible receiver"))
 }
 
 func (r *Runtime) dateproto_getFullYear(call FunctionCall) Value {
@@ -266,7 +266,7 @@ func (r *Runtime) dateproto_getFullYear(call FunctionCall) Value {
 			return _NaN
 		}
 	}
-	panic(r.NewTypeError("Method Date.prototype.getFullYear is called on incompatible receiver"))
+	panic(makeTypeError("Method Date.prototype.getFullYear is called on incompatible receiver"))
 }
 
 func (r *Runtime) dateproto_getUTCFullYear(call FunctionCall) Value {
@@ -278,7 +278,7 @@ func (r *Runtime) dateproto_getUTCFullYear(call FunctionCall) Value {
 			return _NaN
 		}
 	}
-	panic(r.NewTypeError("Method Date.prototype.getUTCFullYear is called on incompatible receiver"))
+	panic(makeTypeError("Method Date.prototype.getUTCFullYear is called on incompatible receiver"))
 }
 
 func (r *Runtime) dateproto_getMonth(call FunctionCall) Value {
@@ -290,7 +290,7 @@ func (r *Runtime) dateproto_getMonth(call FunctionCall) Value {
 			return _NaN
 		}
 	}
-	panic(r.NewTypeError("Method Date.prototype.getMonth is called on incompatible receiver"))
+	panic(makeTypeError("Method Date.prototype.getMonth is called on incompatible receiver"))
 }
 
 func (r *Runtime) dateproto_getUTCMonth(call FunctionCall) Value {
@@ -302,7 +302,7 @@ func (r *Runtime) dateproto_getUTCMonth(call FunctionCall) Value {
 			return _NaN
 		}
 	}
-	panic(r.NewTypeError("Method Date.prototype.getUTCMonth is called on incompatible receiver"))
+	panic(makeTypeError("Method Date.prototype.getUTCMonth is called on incompatible receiver"))
 }
 
 func (r *Runtime) dateproto_getHours(call FunctionCall) Value {
@@ -314,7 +314,7 @@ func (r *Runtime) dateproto_getHours(call FunctionCall) Value {
 			return _NaN
 		}
 	}
-	panic(r.NewTypeError("Method Date.prototype.getHours is called on incompatible receiver"))
+	panic(makeTypeError("Method Date.prototype.getHours is called on incompatible receiver"))
 }
 
 func (r *Runtime) dateproto_getUTCHours(call FunctionCall) Value {
@@ -326,7 +326,7 @@ func (r *Runtime) dateproto_getUTCHours(call FunctionCall) Value {
 			return _NaN
 		}
 	}
-	panic(r.NewTypeError("Method Date.prototype.getUTCHours is called on incompatible receiver"))
+	panic(makeTypeError("Method Date.prototype.getUTCHours is called on incompatible receiver"))
 }
 
 func (r *Runtime) dateproto_getDate(call FunctionCall) Value {
@@ -338,7 +338,7 @@ func (r *Runtime) dateproto_getDate(call FunctionCall) Value {
 			return _NaN
 		}
 	}
-	panic(r.NewTypeError("Method Date.prototype.getDate is called on incompatible receiver"))
+	panic(makeTypeError("Method Date.prototype.getDate is called on incompatible receiver"))
 }
 
 func (r *Runtime) dateproto_getUTCDate(call FunctionCall) Value {
@@ -350,7 +350,7 @@ func (r *Runtime) dateproto_getUTCDate(call FunctionCall) Value {
 			return _NaN
 		}
 	}
-	panic(r.NewTypeError("Method Date.prototype.getUTCDate is called on incompatible receiver"))
+	panic(makeTypeError("Method Date.prototype.getUTCDate is called on incompatible receiver"))
 }
 
 func (r *Runtime) dateproto_getDay(call FunctionCall) Value {
@@ -362,7 +362,7 @@ func (r *Runtime) dateproto_getDay(call FunctionCall) Value {
 			return _NaN
 		}
 	}
-	panic(r.NewTypeError("Method Date.prototype.getDay is called on incompatible receiver"))
+	panic(makeTypeError("Method Date.prototype.getDay is called on incompatible receiver"))
 }
 
 func (r *Runtime) dateproto_getUTCDay(call FunctionCall) Value {
@@ -374,7 +374,7 @@ func (r *Runtime) dateproto_getUTCDay(call FunctionCall) Value {
 			return _NaN
 		}
 	}
-	panic(r.NewTypeError("Method Date.prototype.getUTCDay is called on incompatible receiver"))
+	panic(makeTypeError("Method Date.prototype.getUTCDay is called on incompatible receiver"))
 }
 
 func (r *Runtime) dateproto_getMinutes(call FunctionCall) Value {
@@ -386,7 +386,7 @@ func (r *Runtime) dateproto_getMinutes(call FunctionCall) Value {
 			return _NaN
 		}
 	}
-	panic(r.NewTypeError("Method Date.prototype.getMinutes is called on incompatible receiver"))
+	panic(makeTypeError("Method Date.prototype.getMinutes is called on incompatible receiver"))
 }
 
 func (r *Runtime) dateproto_getUTCMinutes(call FunctionCall) Value {
@@ -398,7 +398,7 @@ func (r *Runtime) dateproto_getUTCMinutes(call FunctionCall) Value {
 			return _NaN
 		}
 	}
-	panic(r.NewTypeError("Method Date.prototype.getUTCMinutes is called on incompatible receiver"))
+	panic(makeTypeError("Method Date.prototype.getUTCMinutes is called on incompatible receiver"))
 }
 
 func (r *Runtime) dateproto_getSeconds(call FunctionCall) Value {
@@ -410,7 +410,7 @@ func (r *Runtime) dateproto_getSeconds(call FunctionCall) Value {
 			return _NaN
 		}
 	}
-	panic(r.NewTypeError("Method Date.prototype.getSeconds is called on incompatible receiver"))
+	panic(makeTypeError("Method Date.prototype.getSeconds is called on incompatible receiver"))
 }
 
 func (r *Runtime) dateproto_getUTCSeconds(call FunctionCall) Value {
@@ -422,7 +422,7 @@ func (r *Runtime) dateproto_getUTCSeconds(call FunctionCall) Value {
 			return _NaN
 		}
 	}
-	panic(r.NewTypeError("Method Date.prototype.getUTCSeconds is called on incompatible receiver"))
+	panic(makeTypeError("Method Date.prototype.getUTCSeconds is called on incompatible receiver"))
 }
 
 func (r *Runtime) dateproto_getMilliseconds(call FunctionCall) Value {
@@ -434,7 +434,7 @@ func (r *Runtime) dateproto_getMilliseconds(call FunctionCall) Value {
 			return _NaN
 		}
 	}
-	panic(r.NewTypeError("Method Date.prototype.getMilliseconds is called on incompatible receiver"))
+	panic(makeTypeError("Method Date.prototype.getMilliseconds is called on incompatible receiver"))
 }
 
 func (r *Runtime) dateproto_getUTCMilliseconds(call FunctionCall) Value {
@@ -446,7 +446,7 @@ func (r *Runtime) dateproto_getUTCMilliseconds(call FunctionCall) Value {
 			return _NaN
 		}
 	}
-	panic(r.NewTypeError("Method Date.prototype.getUTCMilliseconds is called on incompatible receiver"))
+	panic(makeTypeError("Method Date.prototype.getUTCMilliseconds is called on incompatible receiver"))
 }
 
 func (r *Runtime) dateproto_getTimezoneOffset(call FunctionCall) Value {
@@ -459,7 +459,7 @@ func (r *Runtime) dateproto_getTimezoneOffset(call FunctionCall) Value {
 			return _NaN
 		}
 	}
-	panic(r.NewTypeError("Method Date.prototype.getTimezoneOffset is called on incompatible receiver"))
+	panic(makeTypeError("Method Date.prototype.getTimezoneOffset is called on incompatible receiver"))
 }
 
 func (r *Runtime) dateproto_setTime(call FunctionCall) Value {
@@ -472,7 +472,7 @@ func (r *Runtime) dateproto_setTime(call FunctionCall) Value {
 		}
 		return d.setTimeMs(n.ToInteger())
 	}
-	panic(r.NewTypeError("Method Date.prototype.setTime is called on incompatible receiver"))
+	panic(makeTypeError("Method Date.prototype.setTime is called on incompatible receiver"))
 }
 
 // _norm returns nhi, nlo such that
@@ -701,7 +701,7 @@ func (r *Runtime) dateproto_setMilliseconds(call FunctionCall) Value {
 			return _NaN
 		}
 	}
-	panic(r.NewTypeError("Method Date.prototype.setMilliseconds is called on incompatible receiver"))
+	panic(makeTypeError("Method Date.prototype.setMilliseconds is called on incompatible receiver"))
 }
 
 func (r *Runtime) dateproto_setUTCMilliseconds(call FunctionCall) Value {
@@ -726,7 +726,7 @@ func (r *Runtime) dateproto_setUTCMilliseconds(call FunctionCall) Value {
 			return _NaN
 		}
 	}
-	panic(r.NewTypeError("Method Date.prototype.setUTCMilliseconds is called on incompatible receiver"))
+	panic(makeTypeError("Method Date.prototype.setUTCMilliseconds is called on incompatible receiver"))
 }
 
 func (r *Runtime) dateproto_setSeconds(call FunctionCall) Value {
@@ -743,7 +743,7 @@ func (r *Runtime) dateproto_setSeconds(call FunctionCall) Value {
 			return _NaN
 		}
 	}
-	panic(r.NewTypeError("Method Date.prototype.setSeconds is called on incompatible receiver"))
+	panic(makeTypeError("Method Date.prototype.setSeconds is called on incompatible receiver"))
 }
 
 func (r *Runtime) dateproto_setUTCSeconds(call FunctionCall) Value {
@@ -760,7 +760,7 @@ func (r *Runtime) dateproto_setUTCSeconds(call FunctionCall) Value {
 			return _NaN
 		}
 	}
-	panic(r.NewTypeError("Method Date.prototype.setUTCSeconds is called on incompatible receiver"))
+	panic(makeTypeError("Method Date.prototype.setUTCSeconds is called on incompatible receiver"))
 }
 
 func (r *Runtime) dateproto_setMinutes(call FunctionCall) Value {
@@ -777,7 +777,7 @@ func (r *Runtime) dateproto_setMinutes(call FunctionCall) Value {
 			return _NaN
 		}
 	}
-	panic(r.NewTypeError("Method Date.prototype.setMinutes is called on incompatible receiver"))
+	panic(makeTypeError("Method Date.prototype.setMinutes is called on incompatible receiver"))
 }
 
 func (r *Runtime) dateproto_setUTCMinutes(call FunctionCall) Value {
@@ -794,7 +794,7 @@ func (r *Runtime) dateproto_setUTCMinutes(call FunctionCall) Value {
 			return _NaN
 		}
 	}
-	panic(r.NewTypeError("Method Date.prototype.setUTCMinutes is called on incompatible receiver"))
+	panic(makeTypeError("Method Date.prototype.setUTCMinutes is called on incompatible receiver"))
 }
 
 func (r *Runtime) dateproto_setHours(call FunctionCall) Value {
@@ -811,7 +811,7 @@ func (r *Runtime) dateproto_setHours(call FunctionCall) Value {
 			return _NaN
 		}
 	}
-	panic(r.NewTypeError("Method Date.prototype.setHours is called on incompatible receiver"))
+	panic(makeTypeError("Method Date.prototype.setHours is called on incompatible receiver"))
 }
 
 func (r *Runtime) dateproto_setUTCHours(call FunctionCall) Value {
@@ -828,7 +828,7 @@ func (r *Runtime) dateproto_setUTCHours(call FunctionCall) Value {
 			return _NaN
 		}
 	}
-	panic(r.NewTypeError("Method Date.prototype.setUTCHours is called on incompatible receiver"))
+	panic(makeTypeError("Method Date.prototype.setUTCHours is called on incompatible receiver"))
 }
 
 func (r *Runtime) dateproto_setDate(call FunctionCall) Value {
@@ -845,7 +845,7 @@ func (r *Runtime) dateproto_setDate(call FunctionCall) Value {
 			return _NaN
 		}
 	}
-	panic(r.NewTypeError("Method Date.prototype.setDate is called on incompatible receiver"))
+	panic(makeTypeError("Method Date.prototype.setDate is called on incompatible receiver"))
 }
 
 func (r *Runtime) dateproto_setUTCDate(call FunctionCall) Value {
@@ -862,7 +862,7 @@ func (r *Runtime) dateproto_setUTCDate(call FunctionCall) Value {
 			return _NaN
 		}
 	}
-	panic(r.NewTypeError("Method Date.prototype.setUTCDate is called on incompatible receiver"))
+	panic(makeTypeError("Method Date.prototype.setUTCDate is called on incompatible receiver"))
 }
 
 func (r *Runtime) dateproto_setMonth(call FunctionCall) Value {
@@ -879,7 +879,7 @@ func (r *Runtime) dateproto_setMonth(call FunctionCall) Value {
 			return _NaN
 		}
 	}
-	panic(r.NewTypeError("Method Date.prototype.setMonth is called on incompatible receiver"))
+	panic(makeTypeError("Method Date.prototype.setMonth is called on incompatible receiver"))
 }
 
 func (r *Runtime) dateproto_setUTCMonth(call FunctionCall) Value {
@@ -896,7 +896,7 @@ func (r *Runtime) dateproto_setUTCMonth(call FunctionCall) Value {
 			return _NaN
 		}
 	}
-	panic(r.NewTypeError("Method Date.prototype.setUTCMonth is called on incompatible receiver"))
+	panic(makeTypeError("Method Date.prototype.setUTCMonth is called on incompatible receiver"))
 }
 
 func (r *Runtime) dateproto_setFullYear(call FunctionCall) Value {
@@ -915,7 +915,7 @@ func (r *Runtime) dateproto_setFullYear(call FunctionCall) Value {
 		}
 		return d.setTimeMs(timeToMsec(t))
 	}
-	panic(r.NewTypeError("Method Date.prototype.setFullYear is called on incompatible receiver"))
+	panic(makeTypeError("Method Date.prototype.setFullYear is called on incompatible receiver"))
 }
 
 func (r *Runtime) dateproto_setUTCFullYear(call FunctionCall) Value {
@@ -934,7 +934,7 @@ func (r *Runtime) dateproto_setUTCFullYear(call FunctionCall) Value {
 		}
 		return d.setTimeMs(timeToMsec(t))
 	}
-	panic(r.NewTypeError("Method Date.prototype.setUTCFullYear is called on incompatible receiver"))
+	panic(makeTypeError("Method Date.prototype.setUTCFullYear is called on incompatible receiver"))
 }
 
 func (r *Runtime) createDateProto(val *Object) objectImpl {

--- a/builtin_function.go
+++ b/builtin_function.go
@@ -57,7 +57,7 @@ repeat:
 			goto repeat2
 		}
 	}
-	panic(r.NewTypeError("Function.prototype.toString requires that 'this' be a Function"))
+	panic(makeTypeError("Function.prototype.toString requires that 'this' be a Function"))
 }
 
 func (r *Runtime) functionproto_hasInstance(call FunctionCall) Value {

--- a/builtin_map.go
+++ b/builtin_map.go
@@ -100,7 +100,7 @@ func (r *Runtime) mapProto_clear(call FunctionCall) Value {
 	thisObj := r.toObject(call.This)
 	mo, ok := thisObj.self.(*mapObject)
 	if !ok {
-		panic(r.NewTypeError("Method Map.prototype.clear called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: thisObj})))
+		panic(makeTypeError("Method Map.prototype.clear called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: thisObj})))
 	}
 
 	mo.m.clear()
@@ -112,7 +112,7 @@ func (r *Runtime) mapProto_delete(call FunctionCall) Value {
 	thisObj := r.toObject(call.This)
 	mo, ok := thisObj.self.(*mapObject)
 	if !ok {
-		panic(r.NewTypeError("Method Map.prototype.delete called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: thisObj})))
+		panic(makeTypeError("Method Map.prototype.delete called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: thisObj})))
 	}
 
 	return r.toBoolean(mo.m.remove(call.Argument(0)))
@@ -122,7 +122,7 @@ func (r *Runtime) mapProto_get(call FunctionCall) Value {
 	thisObj := r.toObject(call.This)
 	mo, ok := thisObj.self.(*mapObject)
 	if !ok {
-		panic(r.NewTypeError("Method Map.prototype.get called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: thisObj})))
+		panic(makeTypeError("Method Map.prototype.get called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: thisObj})))
 	}
 
 	return nilSafe(mo.m.get(call.Argument(0)))
@@ -132,7 +132,7 @@ func (r *Runtime) mapProto_has(call FunctionCall) Value {
 	thisObj := r.toObject(call.This)
 	mo, ok := thisObj.self.(*mapObject)
 	if !ok {
-		panic(r.NewTypeError("Method Map.prototype.has called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: thisObj})))
+		panic(makeTypeError("Method Map.prototype.has called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: thisObj})))
 	}
 	if mo.m.has(call.Argument(0)) {
 		return valueTrue
@@ -144,7 +144,7 @@ func (r *Runtime) mapProto_set(call FunctionCall) Value {
 	thisObj := r.toObject(call.This)
 	mo, ok := thisObj.self.(*mapObject)
 	if !ok {
-		panic(r.NewTypeError("Method Map.prototype.set called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: thisObj})))
+		panic(makeTypeError("Method Map.prototype.set called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: thisObj})))
 	}
 	mo.m.set(call.Argument(0), call.Argument(1))
 	return call.This
@@ -158,11 +158,11 @@ func (r *Runtime) mapProto_forEach(call FunctionCall) Value {
 	thisObj := r.toObject(call.This)
 	mo, ok := thisObj.self.(*mapObject)
 	if !ok {
-		panic(r.NewTypeError("Method Map.prototype.forEach called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: thisObj})))
+		panic(makeTypeError("Method Map.prototype.forEach called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: thisObj})))
 	}
 	callbackFn, ok := r.toObject(call.Argument(0)).self.assertCallable()
 	if !ok {
-		panic(r.NewTypeError("object is not a function %s"))
+		panic(makeTypeError("object is not a function %s"))
 	}
 	t := call.Argument(1)
 	iter := mo.m.newIter()
@@ -189,14 +189,14 @@ func (r *Runtime) mapProto_getSize(call FunctionCall) Value {
 	thisObj := r.toObject(call.This)
 	mo, ok := thisObj.self.(*mapObject)
 	if !ok {
-		panic(r.NewTypeError("Method get Map.prototype.size called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: thisObj})))
+		panic(makeTypeError("Method get Map.prototype.size called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: thisObj})))
 	}
 	return intToValue(int64(mo.m.size))
 }
 
 func (r *Runtime) builtin_newMap(args []Value, newTarget *Object) *Object {
 	if newTarget == nil {
-		panic(r.needNew("Map"))
+		panic(makeTypeError(needNew, "Map"))
 	}
 	proto := r.getPrototypeFromCtor(newTarget, r.global.Map, r.global.MapPrototype)
 	o := &Object{runtime: r}
@@ -224,7 +224,7 @@ func (r *Runtime) builtin_newMap(args []Value, newTarget *Object) *Object {
 			} else {
 				adderFn := toMethod(adder)
 				if adderFn == nil {
-					panic(r.NewTypeError("Map.set in missing"))
+					panic(makeTypeError("Map.set in missing"))
 				}
 				iter.iterate(func(item Value) {
 					itemObj := r.toObject(item)
@@ -242,7 +242,7 @@ func (r *Runtime) createMapIterator(mapValue Value, kind iterationKind) Value {
 	obj := r.toObject(mapValue)
 	mapObj, ok := obj.self.(*mapObject)
 	if !ok {
-		panic(r.NewTypeError("Object is not a Map"))
+		panic(makeTypeError("Object is not a Map"))
 	}
 
 	o := &Object{runtime: r}
@@ -266,7 +266,7 @@ func (r *Runtime) mapIterProto_next(call FunctionCall) Value {
 	if iter, ok := thisObj.self.(*mapIterObject); ok {
 		return iter.next()
 	}
-	panic(r.NewTypeError("Method Map Iterator.prototype.next called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: thisObj})))
+	panic(makeTypeError("Method Map Iterator.prototype.next called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: thisObj})))
 }
 
 func (r *Runtime) createMapProto(val *Object) objectImpl {

--- a/builtin_number.go
+++ b/builtin_number.go
@@ -20,7 +20,7 @@ func (r *Runtime) numberproto_valueOf(call FunctionCall) Value {
 		}
 	}
 
-	panic(r.NewTypeError("Number.prototype.valueOf is not generic"))
+	panic(makeTypeError("Number.prototype.valueOf is not generic"))
 }
 
 func isNumber(v Value) bool {

--- a/builtin_object.go
+++ b/builtin_object.go
@@ -539,7 +539,7 @@ func (r *Runtime) toProto(proto Value) *Object {
 		if obj, ok := proto.(*Object); ok {
 			return obj
 		} else {
-			panic(r.NewTypeError("Object prototype may only be an Object or null: %s", proto))
+			panic(makeTypeError("Object prototype may only be an Object or null: %s", proto))
 		}
 	}
 	return nil

--- a/builtin_promise.go
+++ b/builtin_promise.go
@@ -1,8 +1,9 @@
 package goja
 
 import (
-	"github.com/dop251/goja/unistring"
 	"reflect"
+
+	"github.com/dop251/goja/unistring"
 )
 
 type PromiseState int
@@ -74,7 +75,7 @@ func (p *Promise) toValue(r *Runtime) Value {
 	}
 	promise := p.val
 	if promise.runtime != r {
-		panic(r.NewTypeError("Illegal runtime transition of a Promise"))
+		panic(makeTypeError("Illegal runtime transition of a Promise"))
 	}
 	return promise
 }
@@ -214,7 +215,7 @@ func (r *Runtime) newPromise(proto *Object) *Promise {
 
 func (r *Runtime) builtin_newPromise(args []Value, newTarget *Object) *Object {
 	if newTarget == nil {
-		panic(r.needNew("Promise"))
+		panic(makeTypeError(needNew, "Promise"))
 	}
 	var arg0 Value
 	if len(args) > 0 {
@@ -244,7 +245,7 @@ func (r *Runtime) promiseProto_then(call FunctionCall) Value {
 		resultCapability := r.newPromiseCapability(c)
 		return r.performPromiseThen(p, call.Argument(0), call.Argument(1), resultCapability)
 	}
-	panic(r.NewTypeError("Method Promise.prototype.then called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: thisObj})))
+	panic(makeTypeError("Method Promise.prototype.then called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: thisObj})))
 }
 
 func (r *Runtime) newPromiseCapability(c *Object) *promiseCapability {
@@ -257,10 +258,10 @@ func (r *Runtime) newPromiseCapability(c *Object) *promiseCapability {
 		var resolve, reject Value
 		executor := r.newNativeFunc(func(call FunctionCall) Value {
 			if resolve != nil {
-				panic(r.NewTypeError("resolve is already set"))
+				panic(makeTypeError("resolve is already set"))
 			}
 			if reject != nil {
-				panic(r.NewTypeError("reject is already set"))
+				panic(makeTypeError("reject is already set"))
 			}
 			if arg := call.Argument(0); arg != _undefined {
 				resolve = arg

--- a/builtin_proxy.go
+++ b/builtin_proxy.go
@@ -338,12 +338,12 @@ func (r *Runtime) newProxy(args []Value, proto *Object) *Object {
 			}
 		}
 	}
-	panic(r.NewTypeError("Cannot create proxy with a non-object as target or handler"))
+	panic(makeTypeError("Cannot create proxy with a non-object as target or handler"))
 }
 
 func (r *Runtime) builtin_newProxy(args []Value, newTarget *Object) *Object {
 	if newTarget == nil {
-		panic(r.needNew("Proxy"))
+		panic(makeTypeError(needNew, "Proxy"))
 	}
 	return r.newProxy(args, r.getPrototypeFromCtor(newTarget, r.global.Proxy, r.global.ObjectPrototype))
 }
@@ -351,7 +351,7 @@ func (r *Runtime) builtin_newProxy(args []Value, newTarget *Object) *Object {
 func (r *Runtime) NewProxy(target *Object, nativeHandler *ProxyTrapConfig) Proxy {
 	if p, ok := target.self.(*proxyObject); ok {
 		if p.handler == nil {
-			panic(r.NewTypeError("Cannot create proxy with a revoked proxy as target"))
+			panic(makeTypeError("Cannot create proxy with a revoked proxy as target"))
 		}
 	}
 	handler := r.newNativeProxyHandler(nativeHandler)
@@ -375,7 +375,7 @@ func (r *Runtime) builtin_proxy_revocable(call FunctionCall) Value {
 			}
 		}
 	}
-	panic(r.NewTypeError("Cannot create proxy with a non-object as target or handler"))
+	panic(makeTypeError("Cannot create proxy with a non-object as target or handler"))
 }
 
 func (r *Runtime) createProxy(val *Object) objectImpl {

--- a/builtin_proxy_test.go
+++ b/builtin_proxy_test.go
@@ -328,7 +328,7 @@ func TestProxy_native_proxy_getOwnPropertyDescriptorIdx(t *testing.T) {
 	a := vm.NewArray()
 	proxy1 := vm.NewProxy(a, &ProxyTrapConfig{
 		GetOwnPropertyDescriptor: func(target *Object, prop string) PropertyDescriptor {
-			panic(vm.NewTypeError("GetOwnPropertyDescriptor was called for %q", prop))
+			panic(makeTypeError("GetOwnPropertyDescriptor was called for %q", prop))
 		},
 		GetOwnPropertyDescriptorIdx: func(target *Object, prop int) PropertyDescriptor {
 			if prop >= -1 && prop <= 1 {
@@ -362,7 +362,7 @@ func TestProxy_native_proxy_getOwnPropertyDescriptorIdx(t *testing.T) {
 			}
 		},
 		GetOwnPropertyDescriptorIdx: func(target *Object, prop int) PropertyDescriptor {
-			panic(vm.NewTypeError("GetOwnPropertyDescriptorIdx was called for %d", prop))
+			panic(makeTypeError("GetOwnPropertyDescriptorIdx was called for %d", prop))
 		},
 	})
 
@@ -400,7 +400,7 @@ func TestProxy_native_proxy_getOwnPropertyDescriptorSym(t *testing.T) {
 	proxy := vm.NewProxy(o, &ProxyTrapConfig{
 		GetOwnPropertyDescriptorSym: func(target *Object, s *Symbol) PropertyDescriptor {
 			if target != o {
-				panic(vm.NewTypeError("Invalid target"))
+				panic(makeTypeError("Invalid target"))
 			}
 			if s == sym {
 				return PropertyDescriptor{
@@ -669,7 +669,7 @@ func TestProxy_native_proxy_get(t *testing.T) {
 				}
 			}
 			if prop == "0" {
-				panic(vm.NewTypeError("GetOwnPropertyDescriptor(0) was called"))
+				panic(makeTypeError("GetOwnPropertyDescriptor(0) was called"))
 			}
 			return
 		},
@@ -688,7 +688,7 @@ func TestProxy_native_proxy_get(t *testing.T) {
 				return propValueStr
 			}
 			if property == "0" {
-				panic(vm.NewTypeError("Get(0) was called"))
+				panic(makeTypeError("Get(0) was called"))
 			}
 			return obj.Get(property)
 		},
@@ -755,21 +755,21 @@ func TestProxy_native_proxy_set(t *testing.T) {
 				obj.Set(property, propValueStr)
 				return true
 			}
-			panic(vm.NewTypeError("Setter for unexpected property: %q", property))
+			panic(makeTypeError("Setter for unexpected property: %q", property))
 		},
 		SetIdx: func(target *Object, property int, value Value, receiver Value) (success bool) {
 			if property == 0 {
 				obj.Set(strconv.Itoa(property), propValueIdx)
 				return true
 			}
-			panic(vm.NewTypeError("Setter for unexpected idx property: %d", property))
+			panic(makeTypeError("Setter for unexpected idx property: %d", property))
 		},
 		SetSym: func(target *Object, property *Symbol, value Value, receiver Value) (success bool) {
 			if property == sym {
 				obj.SetSymbol(property, propValueSym)
 				return true
 			}
-			panic(vm.NewTypeError("Setter for unexpected sym property: %q", property.String()))
+			panic(makeTypeError("Setter for unexpected sym property: %q", property.String()))
 		},
 	})
 	proxyObj := vm.ToValue(proxy).ToObject(vm)
@@ -896,7 +896,7 @@ func TestProxy_native_delete(t *testing.T) {
 				strNegCalled = true
 				return false
 			}
-			panic(vm.NewTypeError("DeleteProperty for unexpected property: %q", property))
+			panic(makeTypeError("DeleteProperty for unexpected property: %q", property))
 		},
 		DeletePropertyIdx: func(target *Object, property int) (success bool) {
 			if property == 0 {
@@ -907,7 +907,7 @@ func TestProxy_native_delete(t *testing.T) {
 				idxNegCalled = true
 				return false
 			}
-			panic(vm.NewTypeError("DeletePropertyIdx for unexpected idx property: %d", property))
+			panic(makeTypeError("DeletePropertyIdx for unexpected idx property: %d", property))
 		},
 		DeletePropertySym: func(target *Object, property *Symbol) (success bool) {
 			if property == sym {
@@ -918,7 +918,7 @@ func TestProxy_native_delete(t *testing.T) {
 				symNegCalled = true
 				return false
 			}
-			panic(vm.NewTypeError("DeletePropertySym for unexpected sym property: %q", property.String()))
+			panic(makeTypeError("DeletePropertySym for unexpected sym property: %q", property.String()))
 		},
 	})
 	proxyObj := vm.ToValue(proxy).ToObject(vm)

--- a/builtin_reflect.go
+++ b/builtin_reflect.go
@@ -10,7 +10,7 @@ func (r *Runtime) toConstructor(v Value) func(args []Value, newTarget *Object) *
 	if ctor := r.toObject(v).self.assertConstructor(); ctor != nil {
 		return ctor
 	}
-	panic(r.NewTypeError("Value is not a constructor"))
+	panic(makeTypeError("Value is not a constructor"))
 }
 
 func (r *Runtime) builtin_reflect_construct(call FunctionCall) Value {

--- a/builtin_regexp.go
+++ b/builtin_regexp.go
@@ -2,11 +2,12 @@ package goja
 
 import (
 	"fmt"
-	"github.com/dop251/goja/parser"
 	"regexp"
 	"strings"
 	"unicode/utf16"
 	"unicode/utf8"
+
+	"github.com/dop251/goja/parser"
 )
 
 func (r *Runtime) newRegexpObject(proto *Object) *regexpObject {
@@ -360,7 +361,7 @@ func (r *Runtime) regexpproto_compile(call FunctionCall) Value {
 		if o, ok := patternVal.(*Object); ok {
 			if p, ok := o.self.(*regexpObject); ok {
 				if flagsVal != _undefined {
-					panic(r.NewTypeError("Cannot supply flags when constructing one RegExp from another"))
+					panic(makeTypeError("Cannot supply flags when constructing one RegExp from another"))
 				}
 				this.pattern = p.pattern
 				this.source = p.source
@@ -386,7 +387,7 @@ func (r *Runtime) regexpproto_compile(call FunctionCall) Value {
 		return call.This
 	}
 
-	panic(r.NewTypeError("Method RegExp.prototype.compile called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
+	panic(makeTypeError("Method RegExp.prototype.compile called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
 }
 
 func (r *Runtime) regexpproto_exec(call FunctionCall) Value {
@@ -406,7 +407,7 @@ func (r *Runtime) regexpproto_test(call FunctionCall) Value {
 			return valueFalse
 		}
 	} else {
-		panic(r.NewTypeError("Method RegExp.prototype.test called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
+		panic(makeTypeError("Method RegExp.prototype.test called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
 	}
 }
 
@@ -503,7 +504,7 @@ func (r *Runtime) regexpproto_getSource(call FunctionCall) Value {
 	} else if call.This == r.global.RegExpPrototype {
 		return asciiString("(?:)")
 	} else {
-		panic(r.NewTypeError("Method RegExp.prototype.source getter called on incompatible receiver"))
+		panic(makeTypeError("Method RegExp.prototype.source getter called on incompatible receiver"))
 	}
 }
 
@@ -517,7 +518,7 @@ func (r *Runtime) regexpproto_getGlobal(call FunctionCall) Value {
 	} else if call.This == r.global.RegExpPrototype {
 		return _undefined
 	} else {
-		panic(r.NewTypeError("Method RegExp.prototype.global getter called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
+		panic(makeTypeError("Method RegExp.prototype.global getter called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
 	}
 }
 
@@ -531,7 +532,7 @@ func (r *Runtime) regexpproto_getMultiline(call FunctionCall) Value {
 	} else if call.This == r.global.RegExpPrototype {
 		return _undefined
 	} else {
-		panic(r.NewTypeError("Method RegExp.prototype.multiline getter called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
+		panic(makeTypeError("Method RegExp.prototype.multiline getter called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
 	}
 }
 
@@ -545,7 +546,7 @@ func (r *Runtime) regexpproto_getIgnoreCase(call FunctionCall) Value {
 	} else if call.This == r.global.RegExpPrototype {
 		return _undefined
 	} else {
-		panic(r.NewTypeError("Method RegExp.prototype.ignoreCase getter called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
+		panic(makeTypeError("Method RegExp.prototype.ignoreCase getter called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
 	}
 }
 
@@ -559,7 +560,7 @@ func (r *Runtime) regexpproto_getUnicode(call FunctionCall) Value {
 	} else if call.This == r.global.RegExpPrototype {
 		return _undefined
 	} else {
-		panic(r.NewTypeError("Method RegExp.prototype.unicode getter called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
+		panic(makeTypeError("Method RegExp.prototype.unicode getter called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
 	}
 }
 
@@ -573,7 +574,7 @@ func (r *Runtime) regexpproto_getSticky(call FunctionCall) Value {
 	} else if call.This == r.global.RegExpPrototype {
 		return _undefined
 	} else {
-		panic(r.NewTypeError("Method RegExp.prototype.sticky getter called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
+		panic(makeTypeError("Method RegExp.prototype.sticky getter called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
 	}
 }
 
@@ -642,7 +643,7 @@ func (r *Runtime) regExpExec(execFn func(FunctionCall) Value, rxObj *Object, arg
 
 	if res != _null {
 		if _, ok := res.(*Object); !ok {
-			panic(r.NewTypeError("RegExp exec method returned something other than an Object or null"))
+			panic(makeTypeError("RegExp exec method returned something other than an Object or null"))
 		}
 	}
 
@@ -654,7 +655,7 @@ func (r *Runtime) getGlobalRegexpMatches(rxObj *Object, s valueString) []Value {
 	rxObj.self.setOwnStr("lastIndex", intToValue(0), true)
 	execFn, ok := r.toObject(rxObj.self.getStr("exec", nil)).self.assertCallable()
 	if !ok {
-		panic(r.NewTypeError("exec is not a function"))
+		panic(makeTypeError("exec is not a function"))
 	}
 	var a []Value
 	for {
@@ -692,7 +693,7 @@ func (r *Runtime) regexpproto_stdMatcherGeneric(rxObj *Object, s valueString) Va
 
 	execFn, ok := r.toObject(rx.getStr("exec", nil)).self.assertCallable()
 	if !ok {
-		panic(r.NewTypeError("exec is not a function"))
+		panic(makeTypeError("exec is not a function"))
 	}
 
 	return r.regExpExec(execFn, rxObj, s)
@@ -748,7 +749,7 @@ func (r *Runtime) regexpproto_stdSearchGeneric(rxObj *Object, arg valueString) V
 	}
 	execFn, ok := r.toObject(rx.getStr("exec", nil)).self.assertCallable()
 	if !ok {
-		panic(r.NewTypeError("exec is not a function"))
+		panic(makeTypeError("exec is not a function"))
 	}
 
 	result := r.regExpExec(execFn, rxObj, arg)
@@ -814,7 +815,7 @@ func regExpExec(r *Object, s valueString) Value {
 	if rx, ok := r.self.(*regexpObject); ok {
 		return rx.exec(s)
 	}
-	panic(r.runtime.NewTypeError("no RegExpMatcher internal slot"))
+	panic(makeTypeError("no RegExpMatcher internal slot"))
 }
 
 func (ri *regExpStringIterObject) next() (v Value) {
@@ -1205,7 +1206,7 @@ func (r *Runtime) regExpStringIteratorProto_next(call FunctionCall) Value {
 	if iter, ok := thisObj.self.(*regExpStringIterObject); ok {
 		return iter.next()
 	}
-	panic(r.NewTypeError("Method RegExp String Iterator.prototype.next called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: thisObj})))
+	panic(makeTypeError("Method RegExp String Iterator.prototype.next called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: thisObj})))
 }
 
 func (r *Runtime) createRegExpStringIteratorPrototype(val *Object) objectImpl {

--- a/builtin_set.go
+++ b/builtin_set.go
@@ -112,7 +112,7 @@ func (r *Runtime) setProto_add(call FunctionCall) Value {
 	thisObj := r.toObject(call.This)
 	so, ok := thisObj.self.(*setObject)
 	if !ok {
-		panic(r.NewTypeError("Method Set.prototype.add called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: thisObj})))
+		panic(makeTypeError("Method Set.prototype.add called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: thisObj})))
 	}
 
 	so.m.set(call.Argument(0), nil)
@@ -123,7 +123,7 @@ func (r *Runtime) setProto_clear(call FunctionCall) Value {
 	thisObj := r.toObject(call.This)
 	so, ok := thisObj.self.(*setObject)
 	if !ok {
-		panic(r.NewTypeError("Method Set.prototype.clear called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: thisObj})))
+		panic(makeTypeError("Method Set.prototype.clear called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: thisObj})))
 	}
 
 	so.m.clear()
@@ -134,7 +134,7 @@ func (r *Runtime) setProto_delete(call FunctionCall) Value {
 	thisObj := r.toObject(call.This)
 	so, ok := thisObj.self.(*setObject)
 	if !ok {
-		panic(r.NewTypeError("Method Set.prototype.delete called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: thisObj})))
+		panic(makeTypeError("Method Set.prototype.delete called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: thisObj})))
 	}
 
 	return r.toBoolean(so.m.remove(call.Argument(0)))
@@ -148,11 +148,11 @@ func (r *Runtime) setProto_forEach(call FunctionCall) Value {
 	thisObj := r.toObject(call.This)
 	so, ok := thisObj.self.(*setObject)
 	if !ok {
-		panic(r.NewTypeError("Method Set.prototype.forEach called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: thisObj})))
+		panic(makeTypeError("Method Set.prototype.forEach called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: thisObj})))
 	}
 	callbackFn, ok := r.toObject(call.Argument(0)).self.assertCallable()
 	if !ok {
-		panic(r.NewTypeError("object is not a function %s"))
+		panic(makeTypeError("object is not a function %s"))
 	}
 	t := call.Argument(1)
 	iter := so.m.newIter()
@@ -171,7 +171,7 @@ func (r *Runtime) setProto_has(call FunctionCall) Value {
 	thisObj := r.toObject(call.This)
 	so, ok := thisObj.self.(*setObject)
 	if !ok {
-		panic(r.NewTypeError("Method Set.prototype.has called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: thisObj})))
+		panic(makeTypeError("Method Set.prototype.has called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: thisObj})))
 	}
 
 	return r.toBoolean(so.m.has(call.Argument(0)))
@@ -181,7 +181,7 @@ func (r *Runtime) setProto_getSize(call FunctionCall) Value {
 	thisObj := r.toObject(call.This)
 	so, ok := thisObj.self.(*setObject)
 	if !ok {
-		panic(r.NewTypeError("Method get Set.prototype.size called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: thisObj})))
+		panic(makeTypeError("Method get Set.prototype.size called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: thisObj})))
 	}
 
 	return intToValue(int64(so.m.size))
@@ -193,7 +193,7 @@ func (r *Runtime) setProto_values(call FunctionCall) Value {
 
 func (r *Runtime) builtin_newSet(args []Value, newTarget *Object) *Object {
 	if newTarget == nil {
-		panic(r.needNew("Set"))
+		panic(makeTypeError(needNew, "Set"))
 	}
 	proto := r.getPrototypeFromCtor(newTarget, r.global.Set, r.global.SetPrototype)
 	o := &Object{runtime: r}
@@ -216,7 +216,7 @@ func (r *Runtime) builtin_newSet(args []Value, newTarget *Object) *Object {
 			} else {
 				adderFn := toMethod(adder)
 				if adderFn == nil {
-					panic(r.NewTypeError("Set.add in missing"))
+					panic(makeTypeError("Set.add in missing"))
 				}
 				iter.iterate(func(item Value) {
 					adderFn(FunctionCall{This: o, Arguments: []Value{item}})
@@ -231,7 +231,7 @@ func (r *Runtime) createSetIterator(setValue Value, kind iterationKind) Value {
 	obj := r.toObject(setValue)
 	setObj, ok := obj.self.(*setObject)
 	if !ok {
-		panic(r.NewTypeError("Object is not a Set"))
+		panic(makeTypeError("Object is not a Set"))
 	}
 
 	o := &Object{runtime: r}
@@ -255,7 +255,7 @@ func (r *Runtime) setIterProto_next(call FunctionCall) Value {
 	if iter, ok := thisObj.self.(*setIterObject); ok {
 		return iter.next()
 	}
-	panic(r.NewTypeError("Method Set Iterator.prototype.next called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: thisObj})))
+	panic(makeTypeError("Method Set Iterator.prototype.next called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: thisObj})))
 }
 
 func (r *Runtime) createSetProto(val *Object) objectImpl {

--- a/builtin_string.go
+++ b/builtin_string.go
@@ -1,11 +1,12 @@
 package goja
 
 import (
-	"github.com/dop251/goja/unistring"
 	"math"
 	"strings"
 	"unicode/utf16"
 	"unicode/utf8"
+
+	"github.com/dop251/goja/unistring"
 
 	"github.com/dop251/goja/parser"
 	"golang.org/x/text/collate"
@@ -260,7 +261,7 @@ func (r *Runtime) stringproto_endsWith(call FunctionCall) Value {
 	s := call.This.toString()
 	searchString := call.Argument(0)
 	if isRegexp(searchString) {
-		panic(r.NewTypeError("First argument to String.prototype.endsWith must not be a regular expression"))
+		panic(makeTypeError("First argument to String.prototype.endsWith must not be a regular expression"))
 	}
 	searchStr := searchString.toString()
 	l := int64(s.length())
@@ -289,7 +290,7 @@ func (r *Runtime) stringproto_includes(call FunctionCall) Value {
 	s := call.This.toString()
 	searchString := call.Argument(0)
 	if isRegexp(searchString) {
-		panic(r.NewTypeError("First argument to String.prototype.includes must not be a regular expression"))
+		panic(makeTypeError("First argument to String.prototype.includes must not be a regular expression"))
 	}
 	searchStr := searchString.toString()
 	var pos int64
@@ -382,7 +383,7 @@ func (r *Runtime) stringproto_match(call FunctionCall) Value {
 		})
 	}
 
-	panic(r.NewTypeError("RegExp matcher is not a function"))
+	panic(makeTypeError("RegExp matcher is not a function"))
 }
 
 func (r *Runtime) stringproto_matchAll(call FunctionCall) Value {
@@ -394,7 +395,7 @@ func (r *Runtime) stringproto_matchAll(call FunctionCall) Value {
 				flags := nilSafe(o.self.getStr("flags", nil))
 				r.checkObjectCoercible(flags)
 				if !strings.Contains(flags.toString().String(), "g") {
-					panic(r.NewTypeError("RegExp doesn't have global flag set"))
+					panic(makeTypeError("RegExp doesn't have global flag set"))
 				}
 			}
 		}
@@ -415,7 +416,7 @@ func (r *Runtime) stringproto_matchAll(call FunctionCall) Value {
 		})
 	}
 
-	panic(r.NewTypeError("RegExp matcher is not a function"))
+	panic(makeTypeError("RegExp matcher is not a function"))
 }
 
 func (r *Runtime) stringproto_normalize(call FunctionCall) Value {
@@ -719,7 +720,7 @@ func (r *Runtime) stringproto_search(call FunctionCall) Value {
 		})
 	}
 
-	panic(r.NewTypeError("RegExp searcher is not a function"))
+	panic(makeTypeError("RegExp searcher is not a function"))
 }
 
 func (r *Runtime) stringproto_slice(call FunctionCall) Value {
@@ -825,7 +826,7 @@ func (r *Runtime) stringproto_startsWith(call FunctionCall) Value {
 	s := call.This.toString()
 	searchString := call.Argument(0)
 	if isRegexp(searchString) {
-		panic(r.NewTypeError("First argument to String.prototype.startsWith must not be a regular expression"))
+		panic(makeTypeError("First argument to String.prototype.startsWith must not be a regular expression"))
 	}
 	searchStr := searchString.toString()
 	l := int64(s.length())
@@ -944,7 +945,7 @@ func (r *Runtime) stringIterProto_next(call FunctionCall) Value {
 	if iter, ok := thisObj.self.(*stringIterObject); ok {
 		return iter.next()
 	}
-	panic(r.NewTypeError("Method String Iterator.prototype.next called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: thisObj})))
+	panic(makeTypeError("Method String Iterator.prototype.next called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: thisObj})))
 }
 
 func (r *Runtime) createStringIterProto(val *Object) objectImpl {

--- a/builtin_symbol.go
+++ b/builtin_symbol.go
@@ -37,7 +37,7 @@ func (r *Runtime) symbolproto_tostring(call FunctionCall) Value {
 		}
 	}
 	if sym == nil {
-		panic(r.NewTypeError("Method Symbol.prototype.toString is called on incompatible receiver"))
+		panic(makeTypeError("Method Symbol.prototype.toString is called on incompatible receiver"))
 	}
 	return sym.descriptiveString()
 }
@@ -56,7 +56,7 @@ func (r *Runtime) symbolproto_valueOf(call FunctionCall) Value {
 		}
 	}
 
-	panic(r.NewTypeError("Symbol.prototype.valueOf requires that 'this' be a Symbol"))
+	panic(makeTypeError("Symbol.prototype.valueOf requires that 'this' be a Symbol"))
 }
 
 func (r *Runtime) symbol_for(call FunctionCall) Value {
@@ -77,7 +77,7 @@ func (r *Runtime) symbol_keyfor(call FunctionCall) Value {
 	arg := call.Argument(0)
 	sym, ok := arg.(*Symbol)
 	if !ok {
-		panic(r.NewTypeError("%s is not a symbol", arg.String()))
+		panic(makeTypeError("%s is not a symbol", arg.String()))
 	}
 	for key, s := range r.symbolRegistry {
 		if s == sym {
@@ -98,7 +98,7 @@ func (r *Runtime) thisSymbolValue(v Value) *Symbol {
 			}
 		}
 	}
-	panic(r.NewTypeError("Value is not a Symbol"))
+	panic(makeTypeError("Value is not a Symbol"))
 }
 
 func (r *Runtime) createSymbolProto(val *Object) objectImpl {
@@ -128,7 +128,7 @@ func (r *Runtime) createSymbolProto(val *Object) objectImpl {
 
 func (r *Runtime) createSymbol(val *Object) objectImpl {
 	o := r.newNativeFuncObj(val, r.builtin_symbol, func(args []Value, proto *Object) *Object {
-		panic(r.NewTypeError("Symbol is not a constructor"))
+		panic(makeTypeError("Symbol is not a constructor"))
 	}, "Symbol", r.global.SymbolPrototype, _positiveZero)
 
 	o._putProp("for", r.newNativeFunc(r.symbol_for, nil, "for", nil, 1), true, false, true)

--- a/builtin_typedarrays.go
+++ b/builtin_typedarrays.go
@@ -76,7 +76,7 @@ func allocByteSlice(size int) (b []byte) {
 
 func (r *Runtime) builtin_newArrayBuffer(args []Value, newTarget *Object) *Object {
 	if newTarget == nil {
-		panic(r.needNew("ArrayBuffer"))
+		panic(makeTypeError(needNew, "ArrayBuffer"))
 	}
 	b := r._newArrayBuffer(r.getPrototypeFromCtor(newTarget, r.global.ArrayBuffer, r.global.ArrayBufferPrototype), nil)
 	if len(args) > 0 {
@@ -93,7 +93,7 @@ func (r *Runtime) arrayBufferProto_getByteLength(call FunctionCall) Value {
 		}
 		return intToValue(0)
 	}
-	panic(r.NewTypeError("Object is not ArrayBuffer: %s", o))
+	panic(makeTypeError("Object is not ArrayBuffer: %s", o))
 }
 
 func (r *Runtime) arrayBufferProto_slice(call FunctionCall) Value {
@@ -114,19 +114,19 @@ func (r *Runtime) arrayBufferProto_slice(call FunctionCall) Value {
 			if newLen > 0 {
 				b.ensureNotDetached(true)
 				if ret == o {
-					panic(r.NewTypeError("Species constructor returned the same ArrayBuffer"))
+					panic(makeTypeError("Species constructor returned the same ArrayBuffer"))
 				}
 				if int64(len(ab.data)) < newLen {
-					panic(r.NewTypeError("Species constructor returned an ArrayBuffer that is too small: %d", len(ab.data)))
+					panic(makeTypeError("Species constructor returned an ArrayBuffer that is too small: %d", len(ab.data)))
 				}
 				ab.ensureNotDetached(true)
 				copy(ab.data, b.data[start:stop])
 			}
 			return ret
 		}
-		panic(r.NewTypeError("Species constructor did not return an ArrayBuffer: %s", ret.String()))
+		panic(makeTypeError("Species constructor did not return an ArrayBuffer: %s", ret.String()))
 	}
-	panic(r.NewTypeError("Object is not ArrayBuffer: %s", o))
+	panic(makeTypeError("Object is not ArrayBuffer: %s", o))
 }
 
 func (r *Runtime) arrayBuffer_isView(call FunctionCall) Value {
@@ -143,7 +143,7 @@ func (r *Runtime) arrayBuffer_isView(call FunctionCall) Value {
 
 func (r *Runtime) newDataView(args []Value, newTarget *Object) *Object {
 	if newTarget == nil {
-		panic(r.needNew("DataView"))
+		panic(makeTypeError(needNew, "DataView"))
 	}
 	proto := r.getPrototypeFromCtor(newTarget, r.global.DataView, r.global.DataViewPrototype)
 	var bufArg Value
@@ -157,7 +157,7 @@ func (r *Runtime) newDataView(args []Value, newTarget *Object) *Object {
 		}
 	}
 	if buffer == nil {
-		panic(r.NewTypeError("First argument to DataView constructor must be an ArrayBuffer"))
+		panic(makeTypeError("First argument to DataView constructor must be an ArrayBuffer"))
 	}
 	var byteOffset, byteLen int
 	if len(args) > 1 {
@@ -197,7 +197,7 @@ func (r *Runtime) dataViewProto_getBuffer(call FunctionCall) Value {
 	if dv, ok := r.toObject(call.This).self.(*dataViewObject); ok {
 		return dv.viewedArrayBuf.val
 	}
-	panic(r.NewTypeError("Method get DataView.prototype.buffer called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
+	panic(makeTypeError("Method get DataView.prototype.buffer called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
 }
 
 func (r *Runtime) dataViewProto_getByteLen(call FunctionCall) Value {
@@ -205,7 +205,7 @@ func (r *Runtime) dataViewProto_getByteLen(call FunctionCall) Value {
 		dv.viewedArrayBuf.ensureNotDetached(true)
 		return intToValue(int64(dv.byteLen))
 	}
-	panic(r.NewTypeError("Method get DataView.prototype.byteLength called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
+	panic(makeTypeError("Method get DataView.prototype.byteLength called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
 }
 
 func (r *Runtime) dataViewProto_getByteOffset(call FunctionCall) Value {
@@ -213,21 +213,21 @@ func (r *Runtime) dataViewProto_getByteOffset(call FunctionCall) Value {
 		dv.viewedArrayBuf.ensureNotDetached(true)
 		return intToValue(int64(dv.byteOffset))
 	}
-	panic(r.NewTypeError("Method get DataView.prototype.byteOffset called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
+	panic(makeTypeError("Method get DataView.prototype.byteOffset called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
 }
 
 func (r *Runtime) dataViewProto_getFloat32(call FunctionCall) Value {
 	if dv, ok := r.toObject(call.This).self.(*dataViewObject); ok {
 		return floatToValue(float64(dv.viewedArrayBuf.getFloat32(dv.getIdxAndByteOrder(r.toIndex(call.Argument(0)), call.Argument(1), 4))))
 	}
-	panic(r.NewTypeError("Method DataView.prototype.getFloat32 called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
+	panic(makeTypeError("Method DataView.prototype.getFloat32 called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
 }
 
 func (r *Runtime) dataViewProto_getFloat64(call FunctionCall) Value {
 	if dv, ok := r.toObject(call.This).self.(*dataViewObject); ok {
 		return floatToValue(dv.viewedArrayBuf.getFloat64(dv.getIdxAndByteOrder(r.toIndex(call.Argument(0)), call.Argument(1), 8)))
 	}
-	panic(r.NewTypeError("Method DataView.prototype.getFloat64 called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
+	panic(makeTypeError("Method DataView.prototype.getFloat64 called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
 }
 
 func (r *Runtime) dataViewProto_getInt8(call FunctionCall) Value {
@@ -235,21 +235,21 @@ func (r *Runtime) dataViewProto_getInt8(call FunctionCall) Value {
 		idx, _ := dv.getIdxAndByteOrder(r.toIndex(call.Argument(0)), call.Argument(1), 1)
 		return intToValue(int64(dv.viewedArrayBuf.getInt8(idx)))
 	}
-	panic(r.NewTypeError("Method DataView.prototype.getInt8 called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
+	panic(makeTypeError("Method DataView.prototype.getInt8 called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
 }
 
 func (r *Runtime) dataViewProto_getInt16(call FunctionCall) Value {
 	if dv, ok := r.toObject(call.This).self.(*dataViewObject); ok {
 		return intToValue(int64(dv.viewedArrayBuf.getInt16(dv.getIdxAndByteOrder(r.toIndex(call.Argument(0)), call.Argument(1), 2))))
 	}
-	panic(r.NewTypeError("Method DataView.prototype.getInt16 called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
+	panic(makeTypeError("Method DataView.prototype.getInt16 called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
 }
 
 func (r *Runtime) dataViewProto_getInt32(call FunctionCall) Value {
 	if dv, ok := r.toObject(call.This).self.(*dataViewObject); ok {
 		return intToValue(int64(dv.viewedArrayBuf.getInt32(dv.getIdxAndByteOrder(r.toIndex(call.Argument(0)), call.Argument(1), 4))))
 	}
-	panic(r.NewTypeError("Method DataView.prototype.getInt32 called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
+	panic(makeTypeError("Method DataView.prototype.getInt32 called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
 }
 
 func (r *Runtime) dataViewProto_getUint8(call FunctionCall) Value {
@@ -257,21 +257,21 @@ func (r *Runtime) dataViewProto_getUint8(call FunctionCall) Value {
 		idx, _ := dv.getIdxAndByteOrder(r.toIndex(call.Argument(0)), call.Argument(1), 1)
 		return intToValue(int64(dv.viewedArrayBuf.getUint8(idx)))
 	}
-	panic(r.NewTypeError("Method DataView.prototype.getUint8 called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
+	panic(makeTypeError("Method DataView.prototype.getUint8 called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
 }
 
 func (r *Runtime) dataViewProto_getUint16(call FunctionCall) Value {
 	if dv, ok := r.toObject(call.This).self.(*dataViewObject); ok {
 		return intToValue(int64(dv.viewedArrayBuf.getUint16(dv.getIdxAndByteOrder(r.toIndex(call.Argument(0)), call.Argument(1), 2))))
 	}
-	panic(r.NewTypeError("Method DataView.prototype.getUint16 called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
+	panic(makeTypeError("Method DataView.prototype.getUint16 called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
 }
 
 func (r *Runtime) dataViewProto_getUint32(call FunctionCall) Value {
 	if dv, ok := r.toObject(call.This).self.(*dataViewObject); ok {
 		return intToValue(int64(dv.viewedArrayBuf.getUint32(dv.getIdxAndByteOrder(r.toIndex(call.Argument(0)), call.Argument(1), 4))))
 	}
-	panic(r.NewTypeError("Method DataView.prototype.getUint32 called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
+	panic(makeTypeError("Method DataView.prototype.getUint32 called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
 }
 
 func (r *Runtime) dataViewProto_setFloat32(call FunctionCall) Value {
@@ -282,7 +282,7 @@ func (r *Runtime) dataViewProto_setFloat32(call FunctionCall) Value {
 		dv.viewedArrayBuf.setFloat32(idx, val, bo)
 		return _undefined
 	}
-	panic(r.NewTypeError("Method DataView.prototype.setFloat32 called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
+	panic(makeTypeError("Method DataView.prototype.setFloat32 called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
 }
 
 func (r *Runtime) dataViewProto_setFloat64(call FunctionCall) Value {
@@ -293,7 +293,7 @@ func (r *Runtime) dataViewProto_setFloat64(call FunctionCall) Value {
 		dv.viewedArrayBuf.setFloat64(idx, val, bo)
 		return _undefined
 	}
-	panic(r.NewTypeError("Method DataView.prototype.setFloat64 called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
+	panic(makeTypeError("Method DataView.prototype.setFloat64 called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
 }
 
 func (r *Runtime) dataViewProto_setInt8(call FunctionCall) Value {
@@ -304,7 +304,7 @@ func (r *Runtime) dataViewProto_setInt8(call FunctionCall) Value {
 		dv.viewedArrayBuf.setInt8(idx, val)
 		return _undefined
 	}
-	panic(r.NewTypeError("Method DataView.prototype.setInt8 called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
+	panic(makeTypeError("Method DataView.prototype.setInt8 called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
 }
 
 func (r *Runtime) dataViewProto_setInt16(call FunctionCall) Value {
@@ -315,7 +315,7 @@ func (r *Runtime) dataViewProto_setInt16(call FunctionCall) Value {
 		dv.viewedArrayBuf.setInt16(idx, val, bo)
 		return _undefined
 	}
-	panic(r.NewTypeError("Method DataView.prototype.setInt16 called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
+	panic(makeTypeError("Method DataView.prototype.setInt16 called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
 }
 
 func (r *Runtime) dataViewProto_setInt32(call FunctionCall) Value {
@@ -326,7 +326,7 @@ func (r *Runtime) dataViewProto_setInt32(call FunctionCall) Value {
 		dv.viewedArrayBuf.setInt32(idx, val, bo)
 		return _undefined
 	}
-	panic(r.NewTypeError("Method DataView.prototype.setInt32 called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
+	panic(makeTypeError("Method DataView.prototype.setInt32 called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
 }
 
 func (r *Runtime) dataViewProto_setUint8(call FunctionCall) Value {
@@ -337,7 +337,7 @@ func (r *Runtime) dataViewProto_setUint8(call FunctionCall) Value {
 		dv.viewedArrayBuf.setUint8(idx, val)
 		return _undefined
 	}
-	panic(r.NewTypeError("Method DataView.prototype.setUint8 called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
+	panic(makeTypeError("Method DataView.prototype.setUint8 called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
 }
 
 func (r *Runtime) dataViewProto_setUint16(call FunctionCall) Value {
@@ -348,7 +348,7 @@ func (r *Runtime) dataViewProto_setUint16(call FunctionCall) Value {
 		dv.viewedArrayBuf.setUint16(idx, val, bo)
 		return _undefined
 	}
-	panic(r.NewTypeError("Method DataView.prototype.setUint16 called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
+	panic(makeTypeError("Method DataView.prototype.setUint16 called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
 }
 
 func (r *Runtime) dataViewProto_setUint32(call FunctionCall) Value {
@@ -359,14 +359,14 @@ func (r *Runtime) dataViewProto_setUint32(call FunctionCall) Value {
 		dv.viewedArrayBuf.setUint32(idx, val, bo)
 		return _undefined
 	}
-	panic(r.NewTypeError("Method DataView.prototype.setUint32 called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
+	panic(makeTypeError("Method DataView.prototype.setUint32 called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
 }
 
 func (r *Runtime) typedArrayProto_getBuffer(call FunctionCall) Value {
 	if ta, ok := r.toObject(call.This).self.(*typedArrayObject); ok {
 		return ta.viewedArrayBuf.val
 	}
-	panic(r.NewTypeError("Method get TypedArray.prototype.buffer called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
+	panic(makeTypeError("Method get TypedArray.prototype.buffer called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
 }
 
 func (r *Runtime) typedArrayProto_getByteLen(call FunctionCall) Value {
@@ -376,7 +376,7 @@ func (r *Runtime) typedArrayProto_getByteLen(call FunctionCall) Value {
 		}
 		return intToValue(int64(ta.length) * int64(ta.elemSize))
 	}
-	panic(r.NewTypeError("Method get TypedArray.prototype.byteLength called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
+	panic(makeTypeError("Method get TypedArray.prototype.byteLength called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
 }
 
 func (r *Runtime) typedArrayProto_getLength(call FunctionCall) Value {
@@ -386,7 +386,7 @@ func (r *Runtime) typedArrayProto_getLength(call FunctionCall) Value {
 		}
 		return intToValue(int64(ta.length))
 	}
-	panic(r.NewTypeError("Method get TypedArray.prototype.length called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
+	panic(makeTypeError("Method get TypedArray.prototype.length called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
 }
 
 func (r *Runtime) typedArrayProto_getByteOffset(call FunctionCall) Value {
@@ -396,7 +396,7 @@ func (r *Runtime) typedArrayProto_getByteOffset(call FunctionCall) Value {
 		}
 		return intToValue(int64(ta.offset) * int64(ta.elemSize))
 	}
-	panic(r.NewTypeError("Method get TypedArray.prototype.byteOffset called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
+	panic(makeTypeError("Method get TypedArray.prototype.byteOffset called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
 }
 
 func (r *Runtime) typedArrayProto_copyWithin(call FunctionCall) Value {
@@ -421,7 +421,7 @@ func (r *Runtime) typedArrayProto_copyWithin(call FunctionCall) Value {
 		}
 		return call.This
 	}
-	panic(r.NewTypeError("Method TypedArray.prototype.copyWithin called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
+	panic(makeTypeError("Method TypedArray.prototype.copyWithin called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
 }
 
 func (r *Runtime) typedArrayProto_entries(call FunctionCall) Value {
@@ -429,7 +429,7 @@ func (r *Runtime) typedArrayProto_entries(call FunctionCall) Value {
 		ta.viewedArrayBuf.ensureNotDetached(true)
 		return r.createArrayIterator(ta.val, iterationKindKeyValue)
 	}
-	panic(r.NewTypeError("Method TypedArray.prototype.entries called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
+	panic(makeTypeError("Method TypedArray.prototype.entries called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
 }
 
 func (r *Runtime) typedArrayProto_every(call FunctionCall) Value {
@@ -454,7 +454,7 @@ func (r *Runtime) typedArrayProto_every(call FunctionCall) Value {
 		return valueTrue
 
 	}
-	panic(r.NewTypeError("Method TypedArray.prototype.every called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
+	panic(makeTypeError("Method TypedArray.prototype.every called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
 }
 
 func (r *Runtime) typedArrayProto_fill(call FunctionCall) Value {
@@ -476,7 +476,7 @@ func (r *Runtime) typedArrayProto_fill(call FunctionCall) Value {
 		}
 		return call.This
 	}
-	panic(r.NewTypeError("Method TypedArray.prototype.fill called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
+	panic(makeTypeError("Method TypedArray.prototype.fill called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
 }
 
 func (r *Runtime) typedArrayProto_filter(call FunctionCall) Value {
@@ -523,7 +523,7 @@ func (r *Runtime) typedArrayProto_filter(call FunctionCall) Value {
 			return ret.val
 		}
 	}
-	panic(r.NewTypeError("Method TypedArray.prototype.filter called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
+	panic(makeTypeError("Method TypedArray.prototype.filter called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
 }
 
 func (r *Runtime) typedArrayProto_find(call FunctionCall) Value {
@@ -547,7 +547,7 @@ func (r *Runtime) typedArrayProto_find(call FunctionCall) Value {
 		}
 		return _undefined
 	}
-	panic(r.NewTypeError("Method TypedArray.prototype.find called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
+	panic(makeTypeError("Method TypedArray.prototype.find called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
 }
 
 func (r *Runtime) typedArrayProto_findIndex(call FunctionCall) Value {
@@ -571,7 +571,7 @@ func (r *Runtime) typedArrayProto_findIndex(call FunctionCall) Value {
 		}
 		return intToValue(-1)
 	}
-	panic(r.NewTypeError("Method TypedArray.prototype.findIndex called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
+	panic(makeTypeError("Method TypedArray.prototype.findIndex called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
 }
 
 func (r *Runtime) typedArrayProto_forEach(call FunctionCall) Value {
@@ -593,7 +593,7 @@ func (r *Runtime) typedArrayProto_forEach(call FunctionCall) Value {
 		}
 		return _undefined
 	}
-	panic(r.NewTypeError("Method TypedArray.prototype.forEach called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
+	panic(makeTypeError("Method TypedArray.prototype.forEach called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
 }
 
 func (r *Runtime) typedArrayProto_includes(call FunctionCall) Value {
@@ -634,7 +634,7 @@ func (r *Runtime) typedArrayProto_includes(call FunctionCall) Value {
 		}
 		return valueFalse
 	}
-	panic(r.NewTypeError("Method TypedArray.prototype.includes called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
+	panic(makeTypeError("Method TypedArray.prototype.includes called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
 }
 
 func (r *Runtime) typedArrayProto_at(call FunctionCall) Value {
@@ -653,7 +653,7 @@ func (r *Runtime) typedArrayProto_at(call FunctionCall) Value {
 		}
 		return _undefined
 	}
-	panic(r.NewTypeError("Method TypedArray.prototype.at called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
+	panic(makeTypeError("Method TypedArray.prototype.at called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
 }
 
 func (r *Runtime) typedArrayProto_indexOf(call FunctionCall) Value {
@@ -689,7 +689,7 @@ func (r *Runtime) typedArrayProto_indexOf(call FunctionCall) Value {
 		}
 		return intToValue(-1)
 	}
-	panic(r.NewTypeError("Method TypedArray.prototype.indexOf called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
+	panic(makeTypeError("Method TypedArray.prototype.indexOf called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
 }
 
 func (r *Runtime) typedArrayProto_join(call FunctionCall) Value {
@@ -729,7 +729,7 @@ func (r *Runtime) typedArrayProto_join(call FunctionCall) Value {
 
 		return buf.String()
 	}
-	panic(r.NewTypeError("Method TypedArray.prototype.join called on incompatible receiver"))
+	panic(makeTypeError("Method TypedArray.prototype.join called on incompatible receiver"))
 }
 
 func (r *Runtime) typedArrayProto_keys(call FunctionCall) Value {
@@ -737,7 +737,7 @@ func (r *Runtime) typedArrayProto_keys(call FunctionCall) Value {
 		ta.viewedArrayBuf.ensureNotDetached(true)
 		return r.createArrayIterator(ta.val, iterationKindKey)
 	}
-	panic(r.NewTypeError("Method TypedArray.prototype.keys called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
+	panic(makeTypeError("Method TypedArray.prototype.keys called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
 }
 
 func (r *Runtime) typedArrayProto_lastIndexOf(call FunctionCall) Value {
@@ -781,7 +781,7 @@ func (r *Runtime) typedArrayProto_lastIndexOf(call FunctionCall) Value {
 
 		return intToValue(-1)
 	}
-	panic(r.NewTypeError("Method TypedArray.prototype.lastIndexOf called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
+	panic(makeTypeError("Method TypedArray.prototype.lastIndexOf called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
 }
 
 func (r *Runtime) typedArrayProto_map(call FunctionCall) Value {
@@ -804,7 +804,7 @@ func (r *Runtime) typedArrayProto_map(call FunctionCall) Value {
 		}
 		return dst.val
 	}
-	panic(r.NewTypeError("Method TypedArray.prototype.map called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
+	panic(makeTypeError("Method TypedArray.prototype.map called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
 }
 
 func (r *Runtime) typedArrayProto_reduce(call FunctionCall) Value {
@@ -825,7 +825,7 @@ func (r *Runtime) typedArrayProto_reduce(call FunctionCall) Value {
 			}
 		}
 		if fc.Arguments[0] == nil {
-			panic(r.NewTypeError("Reduce of empty array with no initial value"))
+			panic(makeTypeError("Reduce of empty array with no initial value"))
 		}
 		for ; k < ta.length; k++ {
 			if ta.isValidIntegerIndex(k) {
@@ -839,7 +839,7 @@ func (r *Runtime) typedArrayProto_reduce(call FunctionCall) Value {
 		}
 		return fc.Arguments[0]
 	}
-	panic(r.NewTypeError("Method TypedArray.prototype.reduce called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
+	panic(makeTypeError("Method TypedArray.prototype.reduce called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
 }
 
 func (r *Runtime) typedArrayProto_reduceRight(call FunctionCall) Value {
@@ -860,7 +860,7 @@ func (r *Runtime) typedArrayProto_reduceRight(call FunctionCall) Value {
 			}
 		}
 		if fc.Arguments[0] == nil {
-			panic(r.NewTypeError("Reduce of empty array with no initial value"))
+			panic(makeTypeError("Reduce of empty array with no initial value"))
 		}
 		for ; k >= 0; k-- {
 			if ta.isValidIntegerIndex(k) {
@@ -874,7 +874,7 @@ func (r *Runtime) typedArrayProto_reduceRight(call FunctionCall) Value {
 		}
 		return fc.Arguments[0]
 	}
-	panic(r.NewTypeError("Method TypedArray.prototype.reduceRight called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
+	panic(makeTypeError("Method TypedArray.prototype.reduceRight called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
 }
 
 func (r *Runtime) typedArrayProto_reverse(call FunctionCall) Value {
@@ -889,7 +889,7 @@ func (r *Runtime) typedArrayProto_reverse(call FunctionCall) Value {
 
 		return call.This
 	}
-	panic(r.NewTypeError("Method TypedArray.prototype.reverse called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
+	panic(makeTypeError("Method TypedArray.prototype.reverse called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
 }
 
 func (r *Runtime) typedArrayProto_set(call FunctionCall) Value {
@@ -966,7 +966,7 @@ func (r *Runtime) typedArrayProto_set(call FunctionCall) Value {
 		}
 		return _undefined
 	}
-	panic(r.NewTypeError("Method TypedArray.prototype.set called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
+	panic(makeTypeError("Method TypedArray.prototype.set called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
 }
 
 func (r *Runtime) typedArrayProto_slice(call FunctionCall) Value {
@@ -1002,7 +1002,7 @@ func (r *Runtime) typedArrayProto_slice(call FunctionCall) Value {
 		}
 		return dst.val
 	}
-	panic(r.NewTypeError("Method TypedArray.prototype.slice called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
+	panic(makeTypeError("Method TypedArray.prototype.slice called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
 }
 
 func (r *Runtime) typedArrayProto_some(call FunctionCall) Value {
@@ -1026,7 +1026,7 @@ func (r *Runtime) typedArrayProto_some(call FunctionCall) Value {
 		}
 		return valueFalse
 	}
-	panic(r.NewTypeError("Method TypedArray.prototype.some called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
+	panic(makeTypeError("Method TypedArray.prototype.some called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
 }
 
 func (r *Runtime) typedArrayProto_sort(call FunctionCall) Value {
@@ -1046,7 +1046,7 @@ func (r *Runtime) typedArrayProto_sort(call FunctionCall) Value {
 		sort.Stable(&ctx)
 		return call.This
 	}
-	panic(r.NewTypeError("Method TypedArray.prototype.sort called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
+	panic(makeTypeError("Method TypedArray.prototype.sort called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
 }
 
 func (r *Runtime) typedArrayProto_subarray(call FunctionCall) Value {
@@ -1066,7 +1066,7 @@ func (r *Runtime) typedArrayProto_subarray(call FunctionCall) Value {
 			intToValue(newLen),
 		}).val
 	}
-	panic(r.NewTypeError("Method TypedArray.prototype.subarray called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
+	panic(makeTypeError("Method TypedArray.prototype.subarray called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
 }
 
 func (r *Runtime) typedArrayProto_toLocaleString(call FunctionCall) Value {
@@ -1083,7 +1083,7 @@ func (r *Runtime) typedArrayProto_toLocaleString(call FunctionCall) Value {
 		}
 		return buf.String()
 	}
-	panic(r.NewTypeError("Method TypedArray.prototype.toLocaleString called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
+	panic(makeTypeError("Method TypedArray.prototype.toLocaleString called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
 }
 
 func (r *Runtime) typedArrayProto_values(call FunctionCall) Value {
@@ -1091,7 +1091,7 @@ func (r *Runtime) typedArrayProto_values(call FunctionCall) Value {
 		ta.viewedArrayBuf.ensureNotDetached(true)
 		return r.createArrayIterator(ta.val, iterationKindValue)
 	}
-	panic(r.NewTypeError("Method TypedArray.prototype.values called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
+	panic(makeTypeError("Method TypedArray.prototype.values called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: call.This})))
 }
 
 func (r *Runtime) typedArrayProto_toStringTag(call FunctionCall) Value {
@@ -1105,7 +1105,7 @@ func (r *Runtime) typedArrayProto_toStringTag(call FunctionCall) Value {
 }
 
 func (r *Runtime) newTypedArray([]Value, *Object) *Object {
-	panic(r.NewTypeError("Abstract class TypedArray not directly constructable"))
+	panic(makeTypeError("Abstract class TypedArray not directly constructable"))
 }
 
 func (r *Runtime) typedArray_from(call FunctionCall) Value {
@@ -1185,13 +1185,13 @@ func (r *Runtime) typedArrayCreate(ctor *Object, args ...Value) *typedArrayObjec
 		if len(args) == 1 {
 			if l, ok := args[0].(valueInt); ok {
 				if ta.length < int(l) {
-					panic(r.NewTypeError("Derived TypedArray constructor created an array which was too small"))
+					panic(makeTypeError("Derived TypedArray constructor created an array which was too small"))
 				}
 			}
 		}
 		return ta
 	}
-	panic(r.NewTypeError("Invalid TypedArray: %s", o))
+	panic(makeTypeError("Invalid TypedArray: %s", o))
 }
 
 func (r *Runtime) typedArrayFrom(ctor, items *Object, mapFn, thisValue Value, taCtor typedArrayObjectCtor, proto *Object) *Object {
@@ -1296,7 +1296,7 @@ func (r *Runtime) _newTypedArrayFromTypedArray(src *typedArrayObject, newTarget 
 
 func (r *Runtime) _newTypedArray(args []Value, newTarget *Object, taCtor typedArrayObjectCtor, proto *Object) *Object {
 	if newTarget == nil {
-		panic(r.needNew("TypedArray"))
+		panic(makeTypeError(needNew, "TypedArray"))
 	}
 	if len(args) > 0 {
 		if obj, ok := args[0].(*Object); ok {

--- a/builtin_weakmap.go
+++ b/builtin_weakmap.go
@@ -37,7 +37,7 @@ func (r *Runtime) weakMapProto_delete(call FunctionCall) Value {
 	thisObj := r.toObject(call.This)
 	wmo, ok := thisObj.self.(*weakMapObject)
 	if !ok {
-		panic(r.NewTypeError("Method WeakMap.prototype.delete called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: thisObj})))
+		panic(makeTypeError("Method WeakMap.prototype.delete called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: thisObj})))
 	}
 	key, ok := call.Argument(0).(*Object)
 	if ok && wmo.m.remove(key) {
@@ -50,7 +50,7 @@ func (r *Runtime) weakMapProto_get(call FunctionCall) Value {
 	thisObj := r.toObject(call.This)
 	wmo, ok := thisObj.self.(*weakMapObject)
 	if !ok {
-		panic(r.NewTypeError("Method WeakMap.prototype.get called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: thisObj})))
+		panic(makeTypeError("Method WeakMap.prototype.get called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: thisObj})))
 	}
 	var res Value
 	if key, ok := call.Argument(0).(*Object); ok {
@@ -66,7 +66,7 @@ func (r *Runtime) weakMapProto_has(call FunctionCall) Value {
 	thisObj := r.toObject(call.This)
 	wmo, ok := thisObj.self.(*weakMapObject)
 	if !ok {
-		panic(r.NewTypeError("Method WeakMap.prototype.has called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: thisObj})))
+		panic(makeTypeError("Method WeakMap.prototype.has called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: thisObj})))
 	}
 	key, ok := call.Argument(0).(*Object)
 	if ok && wmo.m.has(key) {
@@ -79,15 +79,11 @@ func (r *Runtime) weakMapProto_set(call FunctionCall) Value {
 	thisObj := r.toObject(call.This)
 	wmo, ok := thisObj.self.(*weakMapObject)
 	if !ok {
-		panic(r.NewTypeError("Method WeakMap.prototype.set called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: thisObj})))
+		panic(makeTypeError("Method WeakMap.prototype.set called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: thisObj})))
 	}
 	key := r.toObject(call.Argument(0))
 	wmo.m.set(key, call.Argument(1))
 	return call.This
-}
-
-func (r *Runtime) needNew(name string) *Object {
-	return r.NewTypeError("Constructor %s requires 'new'", name)
 }
 
 func (r *Runtime) getPrototypeFromCtor(newTarget, defCtor, defProto *Object) *Object {
@@ -103,7 +99,7 @@ func (r *Runtime) getPrototypeFromCtor(newTarget, defCtor, defProto *Object) *Ob
 
 func (r *Runtime) builtin_newWeakMap(args []Value, newTarget *Object) *Object {
 	if newTarget == nil {
-		panic(r.needNew("WeakMap"))
+		panic(makeTypeError(needNew, "WeakMap"))
 	}
 	proto := r.getPrototypeFromCtor(newTarget, r.global.WeakMap, r.global.WeakMapPrototype)
 	o := &Object{runtime: r}
@@ -131,7 +127,7 @@ func (r *Runtime) builtin_newWeakMap(args []Value, newTarget *Object) *Object {
 			} else {
 				adderFn := toMethod(adder)
 				if adderFn == nil {
-					panic(r.NewTypeError("WeakMap.set in missing"))
+					panic(makeTypeError("WeakMap.set in missing"))
 				}
 				iter.iterate(func(item Value) {
 					itemObj := r.toObject(item)

--- a/builtin_weakset.go
+++ b/builtin_weakset.go
@@ -14,7 +14,7 @@ func (r *Runtime) weakSetProto_add(call FunctionCall) Value {
 	thisObj := r.toObject(call.This)
 	wso, ok := thisObj.self.(*weakSetObject)
 	if !ok {
-		panic(r.NewTypeError("Method WeakSet.prototype.add called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: thisObj})))
+		panic(makeTypeError("Method WeakSet.prototype.add called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: thisObj})))
 	}
 	wso.s.set(r.toObject(call.Argument(0)), nil)
 	return call.This
@@ -24,7 +24,7 @@ func (r *Runtime) weakSetProto_delete(call FunctionCall) Value {
 	thisObj := r.toObject(call.This)
 	wso, ok := thisObj.self.(*weakSetObject)
 	if !ok {
-		panic(r.NewTypeError("Method WeakSet.prototype.delete called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: thisObj})))
+		panic(makeTypeError("Method WeakSet.prototype.delete called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: thisObj})))
 	}
 	obj, ok := call.Argument(0).(*Object)
 	if ok && wso.s.remove(obj) {
@@ -37,7 +37,7 @@ func (r *Runtime) weakSetProto_has(call FunctionCall) Value {
 	thisObj := r.toObject(call.This)
 	wso, ok := thisObj.self.(*weakSetObject)
 	if !ok {
-		panic(r.NewTypeError("Method WeakSet.prototype.has called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: thisObj})))
+		panic(makeTypeError("Method WeakSet.prototype.has called on incompatible receiver %s", r.objectproto_toString(FunctionCall{This: thisObj})))
 	}
 	obj, ok := call.Argument(0).(*Object)
 	if ok && wso.s.has(obj) {
@@ -49,7 +49,7 @@ func (r *Runtime) weakSetProto_has(call FunctionCall) Value {
 func (r *Runtime) populateWeakSetGeneric(s *Object, adderValue Value, iterable Value) {
 	adder := toMethod(adderValue)
 	if adder == nil {
-		panic(r.NewTypeError("WeakSet.add is not set"))
+		panic(makeTypeError("WeakSet.add is not set"))
 	}
 	iter := r.getIterator(iterable, nil)
 	iter.iterate(func(val Value) {
@@ -59,7 +59,7 @@ func (r *Runtime) populateWeakSetGeneric(s *Object, adderValue Value, iterable V
 
 func (r *Runtime) builtin_newWeakSet(args []Value, newTarget *Object) *Object {
 	if newTarget == nil {
-		panic(r.needNew("WeakSet"))
+		panic(makeTypeError(needNew, "WeakSet"))
 	}
 	proto := r.getPrototypeFromCtor(newTarget, r.global.WeakSet, r.global.WeakSetPrototype)
 	o := &Object{runtime: r}

--- a/func.go
+++ b/func.go
@@ -177,7 +177,7 @@ func (f *baseJsFuncObject) construct(args []Value, newTarget *Object) *Object {
 }
 
 func (f *classFuncObject) Call(FunctionCall) Value {
-	panic(f.val.runtime.NewTypeError("Class constructor cannot be invoked without 'new'"))
+	panic(makeTypeError("Class constructor cannot be invoked without 'new'"))
 }
 
 func (f *classFuncObject) assertCallable() (func(FunctionCall) Value, bool) {
@@ -189,7 +189,7 @@ func (f *classFuncObject) createInstance(args []Value, newTarget *Object) (insta
 		if ctor := f.prototype.self.assertConstructor(); ctor != nil {
 			instance = ctor(args, newTarget)
 		} else {
-			panic(f.val.runtime.NewTypeError("Super constructor is not a constructor"))
+			panic(makeTypeError("Super constructor is not a constructor"))
 		}
 	} else {
 		instance = f.baseFuncObject.createInstance(newTarget)
@@ -247,7 +247,7 @@ func (f *classFuncObject) construct(args []Value, newTarget *Object) *Object {
 		if f.derived {
 			r := f.val.runtime
 			if ret != _undefined {
-				panic(r.NewTypeError("Derived constructors may only return object or undefined"))
+				panic(makeTypeError("Derived constructors may only return object or undefined"))
 			}
 			if v := r.vm.stack[r.vm.sp+1]; v != nil { // using residual 'this' value (a bit hacky)
 				instance = r.toObject(v)
@@ -416,7 +416,7 @@ func (f *boundFuncObject) deleteStr(name unistring.String, throw bool) bool {
 
 func (f *boundFuncObject) setOwnStr(name unistring.String, val Value, throw bool) bool {
 	if name == "caller" || name == "arguments" {
-		panic(f.val.runtime.NewTypeError("'caller' and 'arguments' are restricted function properties and cannot be accessed in this context."))
+		panic(makeTypeError("'caller' and 'arguments' are restricted function properties and cannot be accessed in this context."))
 	}
 	return f.nativeFuncObject.setOwnStr(name, val, throw)
 }

--- a/object.go
+++ b/object.go
@@ -379,7 +379,7 @@ func (o *baseObject) checkDeleteProp(name unistring.String, prop *valueProperty,
 	if !prop.configurable {
 		if throw {
 			r := o.val.runtime
-			panic(r.NewTypeError("Cannot delete property '%s' of %s", name, r.objectproto_toString(FunctionCall{This: o.val})))
+			panic(makeTypeError("Cannot delete property '%s' of %s", name, r.objectproto_toString(FunctionCall{This: o.val})))
 		}
 		return false
 	}
@@ -816,7 +816,7 @@ func (o *baseObject) _putSym(s *Symbol, prop Value) {
 func (o *baseObject) getPrivateEnv(typ *privateEnvType, create bool) *privateElements {
 	env := o.privateElements[typ]
 	if env != nil && create {
-		panic(o.val.runtime.NewTypeError("Private fields for the class have already been set"))
+		panic(makeTypeError("Private fields for the class have already been set"))
 	}
 	if env == nil && create {
 		env = &privateElements{
@@ -853,7 +853,7 @@ func (o *Object) genericToPrimitiveNumber() Value {
 		return v
 	}
 
-	panic(o.runtime.NewTypeError("Could not convert %v to primitive", o.self))
+	panic(makeTypeError("Could not convert %v to primitive", o.self))
 }
 
 func (o *baseObject) toPrimitiveNumber() Value {
@@ -869,7 +869,7 @@ func (o *Object) genericToPrimitiveString() Value {
 		return v
 	}
 
-	panic(o.runtime.NewTypeError("Could not convert %v to primitive", o.self))
+	panic(makeTypeError("Could not convert %v to primitive", o.self))
 }
 
 func (o *Object) genericToPrimitive() Value {
@@ -894,7 +894,7 @@ func (o *Object) tryExoticToPrimitive(hint Value) Value {
 		if _, fail := ret.(*Object); !fail {
 			return ret
 		}
-		panic(o.runtime.NewTypeError("Cannot convert object to primitive value"))
+		panic(makeTypeError("Cannot convert object to primitive value"))
 	}
 	return nil
 }
@@ -1411,7 +1411,7 @@ func (o *baseObject) keys(all bool, accum []Value) []Value {
 }
 
 func (o *baseObject) hasInstance(Value) bool {
-	panic(o.val.runtime.NewTypeError("Expecting a function in instanceof check, but got %s", o.val.toString()))
+	panic(makeTypeError("Expecting a function in instanceof check, but got %s", o.val.toString()))
 }
 
 func toMethod(v Value) func(FunctionCall) Value {

--- a/object_dynamic.go
+++ b/object_dynamic.go
@@ -428,7 +428,7 @@ func (o *baseDynamicObject) setProto(proto *Object, throw bool) bool {
 }
 
 func (o *baseDynamicObject) hasInstance(v Value) bool {
-	panic(o.val.runtime.NewTypeError("Expecting a function in instanceof check, but got a dynamic object"))
+	panic(makeTypeError("Expecting a function in instanceof check, but got a dynamic object"))
 }
 
 func (*baseDynamicObject) isExtensible() bool {
@@ -527,7 +527,7 @@ func (*baseDynamicObject) _putSym(s *Symbol, prop Value) {
 }
 
 func (o *baseDynamicObject) getPrivateEnv(*privateEnvType, bool) *privateElements {
-	panic(o.val.runtime.NewTypeError("Dynamic objects cannot have private elements"))
+	panic(makeTypeError("Dynamic objects cannot have private elements"))
 }
 
 func (a *dynamicArray) sortLen() int {

--- a/runtime.go
+++ b/runtime.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"github.com/dop251/goja/file"
 	"go/ast"
 	"hash/maphash"
 	"math"
@@ -14,6 +13,8 @@ import (
 	"runtime"
 	"strconv"
 	"time"
+
+	"github.com/dop251/goja/file"
 
 	"golang.org/x/text/collate"
 
@@ -465,7 +466,7 @@ func (r *Runtime) init() {
 
 func (r *Runtime) typeErrorResult(throw bool, args ...interface{}) {
 	if throw {
-		panic(r.NewTypeError(args...))
+		panic(makeTypeError(args...))
 	}
 }
 
@@ -1720,7 +1721,7 @@ func (r *Runtime) ToValue(i interface{}) Value {
 			return _null
 		}
 		if i.runtime != r {
-			panic(r.NewTypeError("Illegal runtime transition of an Object"))
+			panic(makeTypeError("Illegal runtime transition of an Object"))
 		}
 		return i
 	case valueContainer:
@@ -1936,7 +1937,7 @@ func (r *Runtime) wrapReflectFunc(value reflect.Value) func(FunctionCall) Value 
 			v := reflect.New(t).Elem()
 			err := r.toReflectValue(a, v, &objectExportCtx{})
 			if err != nil {
-				panic(r.NewTypeError("could not convert function call parameter %d: %v", i, err))
+				panic(makeTypeError("could not convert function call parameter %d: %v", i, err))
 			}
 			in[i] = v
 		}
@@ -2457,7 +2458,7 @@ func (r *Runtime) toObject(v Value, args ...interface{}) *Object {
 		return obj
 	}
 	if len(args) > 0 {
-		panic(r.NewTypeError(args...))
+		panic(makeTypeError(args...))
 	} else {
 		var s string
 		if v == nil {
@@ -2465,7 +2466,7 @@ func (r *Runtime) toObject(v Value, args ...interface{}) *Object {
 		} else {
 			s = v.String()
 		}
-		panic(r.NewTypeError("Value is not an object: %s", s))
+		panic(makeTypeError("Value is not an object: %s", s))
 	}
 }
 
@@ -2478,7 +2479,7 @@ func (r *Runtime) toNumber(v Value) Value {
 			return r.toNumber(pvo.pValue)
 		}
 	}
-	panic(r.NewTypeError("Value is not a number: %s", v))
+	panic(makeTypeError("Value is not a number: %s", v))
 }
 
 func (r *Runtime) speciesConstructor(o, defaultConstructor *Object) func(args []Value, newTarget *Object) *Object {
@@ -2502,7 +2503,7 @@ func (r *Runtime) speciesConstructorObj(o, defaultConstructor *Object) *Object {
 	}
 	obj := r.toObject(c)
 	if obj.self.assertConstructor() == nil {
-		panic(r.NewTypeError("Value is not a constructor"))
+		panic(makeTypeError("Value is not a constructor"))
 	}
 	return obj
 }
@@ -2552,7 +2553,7 @@ func (r *Runtime) getIterator(obj Value, method func(FunctionCall) Value) *itera
 	if method == nil {
 		method = toMethod(r.getV(obj, SymIterator))
 		if method == nil {
-			panic(r.NewTypeError("object is not iterable"))
+			panic(makeTypeError("object is not iterable"))
 		}
 	}
 

--- a/typedarrays.go
+++ b/typedarrays.go
@@ -79,7 +79,7 @@ func (a ArrayBuffer) toValue(r *Runtime) Value {
 	}
 	v := a.buf.val
 	if v.runtime != r {
-		panic(r.NewTypeError("Illegal runtime transition of an ArrayBuffer"))
+		panic(makeTypeError("Illegal runtime transition of an ArrayBuffer"))
 	}
 	return v
 }

--- a/value.go
+++ b/value.go
@@ -1,6 +1,7 @@
 package goja
 
 import (
+	"fmt"
 	"hash/maphash"
 	"math"
 	"reflect"
@@ -138,6 +139,19 @@ var (
 	errAccessBeforeInit = referenceError("Cannot access a variable before initialization")
 	errAssignToConst    = typeError("Assignment to constant variable.")
 )
+
+const (
+	needNew = "Constructor %s requires 'new'"
+)
+
+func makeTypeError(args ...interface{}) typeError {
+	msg := ""
+	if len(args) > 0 {
+		f, _ := args[0].(string)
+		msg = fmt.Sprintf(f, args[1:]...)
+	}
+	return typeError(msg)
+}
 
 func propGetter(o Value, v Value, r *Runtime) *Object {
 	if v == _undefined {

--- a/vm.go
+++ b/vm.go
@@ -700,9 +700,9 @@ func (vm *vm) toCallee(v Value) *Object {
 		unresolved.throw()
 		panic("Unreachable")
 	case memberUnresolved:
-		panic(vm.r.NewTypeError("Object has no member '%s'", unresolved.ref))
+		panic(makeTypeError("Object has no member '%s'", unresolved.ref))
 	}
-	panic(vm.r.NewTypeError("Value is not an object: %s", v.toString()))
+	panic(makeTypeError("Value is not an object: %s", v.toString()))
 }
 
 type loadVal uint32
@@ -2064,7 +2064,7 @@ func (g getProp) exec(vm *vm) {
 	v := vm.stack[vm.sp-1]
 	obj := v.baseObject(vm.r)
 	if obj == nil {
-		panic(vm.r.NewTypeError("Cannot read property '%s' of undefined", g))
+		panic(makeTypeError("Cannot read property '%s' of undefined", g))
 	}
 	vm.stack[vm.sp-1] = nilSafe(obj.self.getStr(unistring.String(g), v))
 
@@ -2078,7 +2078,7 @@ func (g getPropRecv) exec(vm *vm) {
 	v := vm.stack[vm.sp-1]
 	obj := v.baseObject(vm.r)
 	if obj == nil {
-		panic(vm.r.NewTypeError("Cannot read property '%s' of undefined", g))
+		panic(makeTypeError("Cannot read property '%s' of undefined", g))
 	}
 	vm.stack[vm.sp-2] = nilSafe(obj.self.getStr(unistring.String(g), recv))
 	vm.sp--
@@ -2092,7 +2092,7 @@ func (g getPropRecvCallee) exec(vm *vm) {
 	v := vm.stack[vm.sp-1]
 	obj := v.baseObject(vm.r)
 	if obj == nil {
-		panic(vm.r.NewTypeError("Cannot read property '%s' of undefined", g))
+		panic(makeTypeError("Cannot read property '%s' of undefined", g))
 	}
 
 	n := unistring.String(g)
@@ -2112,7 +2112,7 @@ func (g getPropCallee) exec(vm *vm) {
 	obj := v.baseObject(vm.r)
 	n := unistring.String(g)
 	if obj == nil {
-		panic(vm.r.NewTypeError("Cannot read property '%s' of undefined or null", n))
+		panic(makeTypeError("Cannot read property '%s' of undefined or null", n))
 	}
 	prop := obj.self.getStr(n, v)
 	if prop == nil {
@@ -2132,7 +2132,7 @@ func (_getElem) exec(vm *vm) {
 	obj := v.baseObject(vm.r)
 	propName := toPropertyKey(vm.stack[vm.sp-1])
 	if obj == nil {
-		panic(vm.r.NewTypeError("Cannot read property '%s' of undefined", propName.String()))
+		panic(makeTypeError("Cannot read property '%s' of undefined", propName.String()))
 	}
 
 	vm.stack[vm.sp-2] = nilSafe(obj.get(propName, v))
@@ -2151,7 +2151,7 @@ func (_getElemRecv) exec(vm *vm) {
 	v := vm.stack[vm.sp-1]
 	obj := v.baseObject(vm.r)
 	if obj == nil {
-		panic(vm.r.NewTypeError("Cannot read property '%s' of undefined", propName.String()))
+		panic(makeTypeError("Cannot read property '%s' of undefined", propName.String()))
 	}
 
 	vm.stack[vm.sp-3] = nilSafe(obj.get(propName, recv))
@@ -2169,7 +2169,7 @@ func (_getKey) exec(vm *vm) {
 	obj := v.baseObject(vm.r)
 	propName := vm.stack[vm.sp-1]
 	if obj == nil {
-		panic(vm.r.NewTypeError("Cannot read property '%s' of undefined", propName.String()))
+		panic(makeTypeError("Cannot read property '%s' of undefined", propName.String()))
 	}
 
 	vm.stack[vm.sp-2] = nilSafe(obj.get(propName, v))
@@ -2187,7 +2187,7 @@ func (_getElemCallee) exec(vm *vm) {
 	obj := v.baseObject(vm.r)
 	propName := toPropertyKey(vm.stack[vm.sp-1])
 	if obj == nil {
-		panic(vm.r.NewTypeError("Cannot read property '%s' of undefined", propName.String()))
+		panic(makeTypeError("Cannot read property '%s' of undefined", propName.String()))
 	}
 
 	prop := obj.get(propName, v)
@@ -2209,7 +2209,7 @@ func (_getElemRecvCallee) exec(vm *vm) {
 	obj := v.baseObject(vm.r)
 	propName := toPropertyKey(vm.stack[vm.sp-1])
 	if obj == nil {
-		panic(vm.r.NewTypeError("Cannot read property '%s' of undefined", propName.String()))
+		panic(makeTypeError("Cannot read property '%s' of undefined", propName.String()))
 	}
 
 	prop := obj.get(propName, recv)
@@ -3650,7 +3650,7 @@ func (vm *vm) checkBindVarsGlobal(names []unistring.String) {
 		} else {
 			for _, name := range names {
 				if !bo.hasOwnPropertyStr(name) {
-					panic(vm.r.NewTypeError("Cannot define global variable '%s', global object is not extensible", name))
+					panic(makeTypeError("Cannot define global variable '%s', global object is not extensible", name))
 				}
 				if _, exists := sn[name]; exists {
 					panic(vm.alreadyDeclared(name))
@@ -3660,7 +3660,7 @@ func (vm *vm) checkBindVarsGlobal(names []unistring.String) {
 	} else {
 		for _, name := range names {
 			if !o.hasOwnPropertyStr(name) && !o.isExtensible() {
-				panic(vm.r.NewTypeError("Cannot define global variable '%s', global object is not extensible", name))
+				panic(makeTypeError("Cannot define global variable '%s', global object is not extensible", name))
 			}
 			if _, exists := sn[name]; exists {
 				panic(vm.alreadyDeclared(name))
@@ -3763,7 +3763,7 @@ func (vm *vm) checkBindFuncsGlobal(names []unistring.String) {
 			allowed = prop.configurable || prop.getterFunc == nil && prop.setterFunc == nil && prop.writable && prop.enumerable
 		}
 		if !allowed {
-			panic(vm.r.NewTypeError("Cannot redefine global function '%s'", name))
+			panic(makeTypeError("Cannot redefine global function '%s'", name))
 		}
 	}
 }
@@ -4282,7 +4282,7 @@ func (s superCall) exec(vm *vm) {
 		cls, _ = fn.funcObj.self.(*classFuncObject)
 	}
 	if cls == nil {
-		panic(vm.r.NewTypeError("wrong callee type for super()"))
+		panic(makeTypeError("wrong callee type for super()"))
 	}
 	sp := vm.sp - int(s)
 	newTarget := vm.r.toObject(vm.newTarget)
@@ -4850,14 +4850,14 @@ func (c *newDerivedClass) exec(vm *vm) {
 	var superClass *Object
 	if o := vm.stack[vm.sp-1]; o != _null {
 		if sc, ok := o.(*Object); !ok || sc.self.assertConstructor() == nil {
-			panic(vm.r.NewTypeError("Class extends value is not a constructor or null"))
+			panic(makeTypeError("Class extends value is not a constructor or null"))
 		} else {
 			v := sc.self.getStr("prototype", nil)
 			if v != _null {
 				if o, ok := v.(*Object); ok {
 					protoParent = o
 				} else {
-					panic(vm.r.NewTypeError("Class extends value does not have valid prototype property"))
+					panic(makeTypeError("Class extends value does not have valid prototype property"))
 				}
 			}
 			superClass = sc
@@ -4992,7 +4992,7 @@ func (offset defineComputedKey) exec(vm *vm) {
 		vm.pc++
 		return
 	}
-	panic(vm.r.NewTypeError("Compiler bug: unexpected target for defineComputedKey: %v", obj))
+	panic(makeTypeError("Compiler bug: unexpected target for defineComputedKey: %v", obj))
 }
 
 type loadComputedKey int
@@ -5004,7 +5004,7 @@ func (idx loadComputedKey) exec(vm *vm) {
 		vm.pc++
 		return
 	}
-	panic(vm.r.NewTypeError("Compiler bug: unexpected target for loadComputedKey: %v", obj))
+	panic(makeTypeError("Compiler bug: unexpected target for loadComputedKey: %v", obj))
 }
 
 type initStaticElements struct {
@@ -5028,7 +5028,7 @@ func (i *initStaticElements) exec(vm *vm) {
 		vm.pc++
 		return
 	}
-	panic(vm.r.NewTypeError("Compiler bug: unexpected target for initStaticElements: %v", staticInit))
+	panic(makeTypeError("Compiler bug: unexpected target for initStaticElements: %v", staticInit))
 }
 
 type definePrivateMethod struct {
@@ -5041,7 +5041,7 @@ func (d *definePrivateMethod) getPrivateMethods(vm *vm) []Value {
 	if cls, ok := obj.self.(*classFuncObject); ok {
 		return cls.privateMethods
 	} else {
-		panic(vm.r.NewTypeError("Compiler bug: wrong target type for definePrivateMethod: %T", obj.self))
+		panic(makeTypeError("Compiler bug: wrong target type for definePrivateMethod: %T", obj.self))
 	}
 }
 
@@ -5068,7 +5068,7 @@ func (d *definePrivateGetter) exec(vm *vm) {
 		methods[d.idx] = p
 	}
 	if p.getterFunc != nil {
-		panic(vm.r.NewTypeError("Private getter has already been declared"))
+		panic(makeTypeError("Private getter has already been declared"))
 	}
 	p.getterFunc = method
 	vm.sp--
@@ -5091,7 +5091,7 @@ func (d *definePrivateSetter) exec(vm *vm) {
 		methods[d.idx] = p
 	}
 	if p.setterFunc != nil {
-		panic(vm.r.NewTypeError("Private setter has already been declared"))
+		panic(makeTypeError("Private setter has already been declared"))
 	}
 	p.setterFunc = method
 	vm.sp--
@@ -5162,15 +5162,15 @@ func (vm *vm) getPrivateProp(base Value, name unistring.String, typ *privateEnvT
 		} else {
 			v = penv.fields[idx]
 			if v == nil {
-				panic(vm.r.NewTypeError("Private member #%s is accessed before it is initialized", name))
+				panic(makeTypeError("Private member #%s is accessed before it is initialized", name))
 			}
 		}
 	} else {
-		panic(vm.r.NewTypeError("Cannot read private member #%s from an object whose class did not declare it", name))
+		panic(makeTypeError("Cannot read private member #%s from an object whose class did not declare it", name))
 	}
 	if prop, ok := v.(*valueProperty); ok {
 		if prop.getterFunc == nil {
-			panic(vm.r.NewTypeError("'#%s' was defined without a getter", name))
+			panic(makeTypeError("'#%s' was defined without a getter", name))
 		}
 		v = prop.get(obj)
 	}
@@ -5199,20 +5199,20 @@ func (vm *vm) setPrivateProp(base Value, name unistring.String, typ *privateEnvT
 				if prop.setterFunc != nil {
 					prop.set(base, val)
 				} else {
-					panic(vm.r.NewTypeError("Cannot assign to read only property '#%s'", name))
+					panic(makeTypeError("Cannot assign to read only property '#%s'", name))
 				}
 			} else {
-				panic(vm.r.NewTypeError("Private method '#%s' is not writable", name))
+				panic(makeTypeError("Private method '#%s' is not writable", name))
 			}
 		} else {
 			ptr := &penv.fields[idx]
 			if *ptr == nil {
-				panic(vm.r.NewTypeError("Private member #%s is accessed before it is initialized", name))
+				panic(makeTypeError("Private member #%s is accessed before it is initialized", name))
 			}
 			*ptr = val
 		}
 	} else {
-		panic(vm.r.NewTypeError("Cannot write private member #%s from an object whose class did not declare it", name))
+		panic(makeTypeError("Cannot write private member #%s from an object whose class did not declare it", name))
 	}
 }
 


### PR DESCRIPTION
about throw TypeError, dependencies on (*runtime) should be avoided.
So I made the following changes to increase code robustness.

add func:
func makeTypeError(args ...interface{}) typeError

replace:
panic\(.*NewTypeError\(
to:
panic(makeTypeError(

remove: func needNew
add: const  needNew

replace:
panic(r.needNew(
to:
panic(makeTypeError(needNew, 

After modifying the code, all TypeErrors will be thrown by panic(typeError).
Finally, the correct (*runtime).NewTypeError is called in "case typeError"
