### PR TITLE
Build correct base object from importedString

### DIFF
--- a/string_imported.go
+++ b/string_imported.go
@@ -133,6 +133,10 @@ func (i *importedString) ExportType() reflect.Type {
 }
 
 func (i *importedString) baseObject(r *Runtime) *Object {
+	i.ensureScanned()
+	if i.u != nil {
+		return i.u.baseObject(r)
+	}
 	return asciiString(i.s).baseObject(r)
 }
 

--- a/string_test.go
+++ b/string_test.go
@@ -133,6 +133,7 @@ func TestImportedString(t *testing.T) {
 
 	for i, a := range strs {
 		testUnaryOp(a, "JSON.parse(JSON.stringify(a))", a, t)
+		testUnaryOp(a, "a.length", int64(len(utf16.Encode([]rune(a)))), t)
 		for j, b := range strs {
 			testBinaryOp(a, b, "a === b", a == b, t)
 			testBinaryOp(a, b, "a == b", a == b, t)


### PR DESCRIPTION
This for example was completely breaking .length() on unicode strings