### PR TITLE
Skip hashbang at beginning of source contents

### DIFF
--- a/builtin_function_test.go
+++ b/builtin_function_test.go
@@ -1,0 +1,14 @@
+package goja
+
+import (
+	"testing"
+)
+
+func TestHashbangInFunctionConstructor(t *testing.T) {
+	const SCRIPT = `
+	assert.throws(SyntaxError, function() {
+		new Function("#!")
+	});
+	`
+	testScriptWithTestLib(SCRIPT, _undefined, t)
+}

--- a/parser/lexer.go
+++ b/parser/lexer.go
@@ -425,6 +425,11 @@ func (self *_parser) scan() (tkn token.Token, literal string, parsedLiteral unis
 			case '`':
 				tkn = token.BACKTICK
 			case '#':
+				if self.chrOffset == 1 && self.chr == '!' {
+					self.skipSingleLineComment()
+					continue
+				}
+
 				var err string
 				literal, parsedLiteral, _, err = self.scanIdentifier()
 				if err != "" || literal == "" {

--- a/parser/lexer_test.go
+++ b/parser/lexer_test.go
@@ -39,6 +39,15 @@ func TestLexer(t *testing.T) {
 			token.EOF, "", 1,
 		)
 
+		test("#!",
+			token.EOF, "", 3,
+		)
+
+		test("#!\n1",
+			token.NUMBER, "1", 4,
+			token.EOF, "", 5,
+		)
+
 		test("1",
 			token.NUMBER, "1", 1,
 			token.EOF, "", 2,

--- a/tc39_test.go
+++ b/tc39_test.go
@@ -220,6 +220,7 @@ var (
 		"test/language/statements/class/elements/private-async-method-name.js":                                                         true,
 		"test/language/expressions/in/private-field-rhs-await-present.js":                                                              true,
 		"test/language/expressions/class/elements/private-static-async-method-name.js":                                                 true,
+		"test/language/comments/hashbang/function-constructor.js":                                                                      true,
 
 		// legacy number literals
 		"test/language/literals/numeric/non-octal-decimal-integer.js": true,
@@ -290,7 +291,6 @@ var (
 		"error-cause",
 		"decorators",
 		"regexp-v-flag",
-		"hashbang",
 	}
 )
 


### PR DESCRIPTION
Small modification for the lexer that enables skipping of the initial hashbang in the contents of a JavaScript script.
Tests with the `hashbang` feature in Test262 have therefore been enabled; except one (`function-constructor.js`) which makes use of `async`. To make up for this, I've added the `TestHashbangInFunctionConstructor` test written in Go.