### PR TITLE
Optimize Math.{min,max}()

### DIFF
--- a/builtin_math.go
+++ b/builtin_math.go
@@ -5,11 +5,6 @@ import (
 	"math/bits"
 )
 
-var (
-	_realNegativeInf = math.Inf(-1)
-	_realPositiveInf = math.Inf(1)
-)
-
 func (r *Runtime) math_abs(call FunctionCall) Value {
 	return floatToValue(math.Abs(call.Argument(0).ToFloat()))
 }
@@ -143,7 +138,7 @@ func (r *Runtime) math_log2(call FunctionCall) Value {
 }
 
 func (r *Runtime) math_max(call FunctionCall) Value {
-	result := _realNegativeInf
+	result := math.Inf(-1)
 	args := call.Arguments
 	for i, arg := range args {
 		n := nilSafe(arg).ToFloat()
@@ -167,7 +162,7 @@ NaNLoop:
 }
 
 func (r *Runtime) math_min(call FunctionCall) Value {
-	result := _realPositiveInf
+	result := math.Inf(1)
 	args := call.Arguments
 	for i, arg := range args {
 		n := nilSafe(arg).ToFloat()

--- a/builtin_math.go
+++ b/builtin_math.go
@@ -5,6 +5,11 @@ import (
 	"math/bits"
 )
 
+var (
+	_realNegativeInf = math.Inf(-1)
+	_realPositiveInf = math.Inf(1)
+)
+
 func (r *Runtime) math_abs(call FunctionCall) Value {
 	return floatToValue(math.Abs(call.Argument(0).ToFloat()))
 }
@@ -138,7 +143,7 @@ func (r *Runtime) math_log2(call FunctionCall) Value {
 }
 
 func (r *Runtime) math_max(call FunctionCall) Value {
-	result := math.Inf(-1)
+	result := _realNegativeInf
 	args := call.Arguments
 	for i, arg := range args {
 		n := nilSafe(arg).ToFloat()
@@ -146,7 +151,9 @@ func (r *Runtime) math_max(call FunctionCall) Value {
 			args = args[i+1:]
 			goto NaNLoop
 		}
-		result = math.Max(result, n)
+		if n > result || (n == 0 && n == result && !math.Signbit(n)) {
+			result = n
+		}
 	}
 
 	return floatToValue(result)
@@ -160,7 +167,7 @@ NaNLoop:
 }
 
 func (r *Runtime) math_min(call FunctionCall) Value {
-	result := math.Inf(1)
+	result := _realPositiveInf
 	args := call.Arguments
 	for i, arg := range args {
 		n := nilSafe(arg).ToFloat()
@@ -168,7 +175,9 @@ func (r *Runtime) math_min(call FunctionCall) Value {
 			args = args[i+1:]
 			goto NaNLoop
 		}
-		result = math.Min(result, n)
+		if n < result || (n == 0 && n == result && math.Signbit(n)) {
+			result = n
+		}
 	}
 
 	return floatToValue(result)


### PR DESCRIPTION
Replace usage of Go std math.Min/Max with custom checks.
Results in a *very* slight performance improvement (~2.5%).