### PR TITLE
fix: add primitive ptr for method of Runtime.toValue

### DIFF
--- a/runtime.go
+++ b/runtime.go
@@ -1851,6 +1851,15 @@ func (r *Runtime) toValue(i interface{}, origValue reflect.Value) Value {
 		} else {
 			return valueFalse
 		}
+	case *bool:
+		if i == nil {
+			return _null
+		}
+		if *i {
+			return valueTrue
+		} else {
+			return valueFalse
+		}
 	case func(FunctionCall) Value:
 		name := unistring.NewFromString(runtime.FuncForPC(reflect.ValueOf(i).Pointer()).Name())
 		return r.newNativeFunc(i, nil, name, nil, 0)
@@ -1869,35 +1878,102 @@ func (r *Runtime) toValue(i interface{}, origValue reflect.Value) Value {
 		}, name, 0)
 	case int:
 		return intToValue(int64(i))
+	case *int:
+		if i == nil {
+			return _null
+		}
+		return intToValue(int64(*i))
 	case int8:
 		return intToValue(int64(i))
+	case *int8:
+		if i == nil {
+			return _null
+		}
+		return intToValue(int64(*i))
 	case int16:
 		return intToValue(int64(i))
+	case *int16:
+		if i == nil {
+			return _null
+		}
+		return intToValue(int64(*i))
 	case int32:
 		return intToValue(int64(i))
+	case *int32:
+		if i == nil {
+			return _null
+		}
+		return intToValue(int64(*i))
 	case int64:
 		return intToValue(i)
+	case *int64:
+		if i == nil {
+			return _null
+		}
+		return intToValue(*i)
 	case uint:
 		if uint64(i) <= math.MaxInt64 {
 			return intToValue(int64(i))
 		} else {
 			return floatToValue(float64(i))
 		}
+	case *uint:
+		if i == nil {
+			return _null
+		}
+		if uint64(*i) <= math.MaxInt64 {
+			return intToValue(int64(*i))
+		} else {
+			return floatToValue(float64(*i))
+		}
 	case uint8:
 		return intToValue(int64(i))
+	case *uint8:
+		if i == nil {
+			return _null
+		}
+		return intToValue(int64(*i))
 	case uint16:
 		return intToValue(int64(i))
+	case *uint16:
+		if i == nil {
+			return _null
+		}
+		return intToValue(int64(*i))
 	case uint32:
 		return intToValue(int64(i))
+	case *uint32:
+		if i == nil {
+			return _null
+		}
+		return intToValue(int64(*i))
 	case uint64:
 		if i <= math.MaxInt64 {
 			return intToValue(int64(i))
 		}
 		return floatToValue(float64(i))
+	case *uint64:
+		if i == nil {
+			return _null
+		}
+		if *i <= math.MaxInt64 {
+			return intToValue(int64(*i))
+		}
+		return floatToValue(float64(*i))
 	case float32:
 		return floatToValue(float64(i))
+	case *float32:
+		if i == nil {
+			return _null
+		}
+		return floatToValue(float64(*i))
 	case float64:
 		return floatToValue(i)
+	case *float64:
+		if i == nil {
+			return _null
+		}
+		return floatToValue(*i)
 	case map[string]interface{}:
 		if i == nil {
 			return _null

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -302,6 +302,61 @@ func TestObjectGetSet(t *testing.T) {
 	}
 }
 
+func TestRuntime_ToValue_FromPrimitivePtr(t *testing.T) {
+	type tt struct {
+		scene  string
+		input  interface{}
+		expect interface{}
+	}
+
+	for _, next := range []tt{
+		{"BoolPtrNil", (*bool)(nil), nil},
+		{"BoolPtrFalse", new(bool), false},
+		{
+			"BoolPtrTrue",
+			func() interface{} {
+				b := new(bool)
+				*b = true
+				return b
+			}(),
+			true,
+		},
+		{"Int8PtrNil", (*int8)(nil), nil},
+		{"Int8Ptr", new(int8), int64(0)},
+		{"Int16PtrNil", (*int16)(nil), nil},
+		{"Int16Ptr", new(int16), int64(0)},
+		{"Int32PtrNil", (*int32)(nil), nil},
+		{"Int32Ptr", new(int32), int64(0)},
+		{"Int64PtrNil", (*int64)(nil), nil},
+		{"Int64Ptr", new(int64), int64(0)},
+		{"IntPtrNil", (*int)(nil), nil},
+		{"IntPtr", new(int), int64(0)},
+		{"Uint8PtrNil", (*uint8)(nil), nil},
+		{"Uint8Ptr", new(uint8), int64(0)},
+		{"Uint16PtrNil", (*uint16)(nil), nil},
+		{"Uint16Ptr", new(uint16), int64(0)},
+		{"Uint32PtrNil", (*uint32)(nil), nil},
+		{"Uint32Ptr", new(uint32), int64(0)},
+		{"Uint64PtrNil", (*uint64)(nil), nil},
+		{"Uint64Ptr", new(uint64), int64(0)},
+		{"UintPtrNil", (*uint)(nil), nil},
+		{"UintPtr", new(uint), int64(0)},
+		{"Float32PtrNil", (*float32)(nil), nil},
+		{"Float32Ptr", new(float32), int64(0)},
+		{"Float64PtrNil", (*float64)(nil), nil},
+		{"Float64Ptr", new(float64), int64(0)},
+	} {
+		t.Run(next.scene, func(t *testing.T) {
+			r := New()
+			val := r.ToValue(next.input)
+			export := val.Export()
+			if !reflect.DeepEqual(next.expect, export) {
+				t.Fatalf("Unexpected test value: %v (%T)", val, export)
+			}
+		})
+	}
+}
+
 func TestThrowFromNativeFunc(t *testing.T) {
 	const SCRIPT = `
 	var thrown;


### PR DESCRIPTION
## Problem
We use goja as script engine in our project, and there are many primitive-ptr data we need to handle, some behaviors in goja are unexpected, for example `new(bool)` should mean `false`, but actually it will be `truth` because of pointer is not zero.

## Solution
I raise this PR, trying to resolve this situation, see the snippets below:

```go
package main

import (
	"encoding/json"
	"fmt"
	"strings"

	"github.com/dop251/goja"
)

type UserInfo struct {
	ID    int64  `json:"id"`
	Name  string `json:"name"`
	Adult *bool  `json:"adult,omitempty"` // optional property, and it's a bool ptr
}

func main() {
	var userinfo UserInfo
	// set property 'adult' as false
	_ = json.NewDecoder(strings.NewReader(`{"id":1234,"name":"foobar","adult":false}`)).Decode(&userinfo)

	vm := goja.New()
	vm.SetFieldNameMapper(goja.UncapFieldNameMapper())
	vm.Set("session", map[string]interface{}{
		"user": &userinfo,
	})

	ret, _ := vm.RunString(`session.user.adult ? 'user is adult' : 'user is not adult'`)

	fmt.Println("result:", ret.Export())
	// BEFORE PR:
	// result: user is adult

	// AFTER PR:
	// result: user is not adult
}

```

Thanks for figuring out any problem in the PR. We like goja very much, it helps us a lot. 😀 
