### PR TITLE
Implement String.prototype.replaceAll

### DIFF
--- a/string_ascii.go
+++ b/string_ascii.go
@@ -313,6 +313,9 @@ func (s asciiString) CompareTo(other String) int {
 func (s asciiString) index(substr String, start int) int {
 	a, u := devirtualizeString(substr)
 	if u == nil {
+		if start > len(s) {
+			return -1
+		}
 		p := strings.Index(string(s[start:]), string(a))
 		if p >= 0 {
 			return p + start

--- a/tc39_test.go
+++ b/tc39_test.go
@@ -196,13 +196,15 @@ var (
 		// Character \ missing from character class [\c]
 		"test/annexB/built-ins/RegExp/RegExp-invalid-control-escape-character-class.js": true,
 		"test/annexB/built-ins/RegExp/RegExp-control-escape-russian-letter.js":          true,
+
+		// Skip due to regexp named groups
+		"test/built-ins/String/prototype/replaceAll/searchValue-replacer-RegExp-call.js": true,
 	}
 
 	featuresBlackList = []string{
 		"async-iteration",
 		"Symbol.asyncIterator",
 		"BigInt",
-		"String.prototype.replaceAll",
 		"resizable-arraybuffer",
 		"regexp-named-groups",
 		"regexp-dotall",


### PR DESCRIPTION
Skip the https://github.com/tc39/test262/blob/main/test/built-ins/String/prototype/replaceAll/searchValue-replacer-RegExp-call.js due to regexp named groups.