### PR TITLE
fix the issue that the stack trace location is not full, when throw e…

### DIFF
--- a/runtime_test.go
+++ b/runtime_test.go
@@ -2325,14 +2325,18 @@ func TestStacktraceLocationThrowFromCatch(t *testing.T) {
 		t.Fatal("Expected error")
 	}
 	stack := err.(*Exception).stack
-	if len(stack) != 2 {
+	if len(stack) != 3 {
 		t.Fatalf("Unexpected stack len: %v", stack)
 	}
-	if frame := stack[0]; frame.funcName != "main" || frame.pc != 29 {
+
+	if frame := stack[0]; frame.funcName != "f2" || frame.pc != 2 {
 		t.Fatalf("Unexpected stack frame 0: %#v", frame)
 	}
-	if frame := stack[1]; frame.funcName != "" || frame.pc != 7 {
+	if frame := stack[1]; frame.funcName != "main" || frame.pc != 15 {
 		t.Fatalf("Unexpected stack frame 1: %#v", frame)
+	}
+	if frame := stack[2]; frame.funcName != "" || frame.pc != 7 {
+		t.Fatalf("Unexpected stack frame 2: %#v", frame)
 	}
 }
 

--- a/vm.go
+++ b/vm.go
@@ -4462,6 +4462,15 @@ func (_throw) exec(vm *vm) {
 	}
 
 	if ex = vm.handleThrow(ex); ex != nil {
+		// Get the full Error stacks
+		if o, ok := v.(*Object); ok {
+			if e, ok := o.self.(*errorObject); ok {
+				ex = &Exception{
+					val:   v,
+					stack: e.stack,
+				}
+			}
+		}
 		panic(ex)
 	}
 }


### PR DESCRIPTION
Fix the issue that the stack trace location is not full, when throw error from catch. I think that print all stack trace info when program occur error. fix issue: #517
@dop251 