### PR TITLE
Convert []uint8 to Uint8Array

### DIFF
--- a/builtin_typedarrays.go
+++ b/builtin_typedarrays.go
@@ -1451,7 +1451,7 @@ func (r *Runtime) getTypedArray() *Object {
 	return ret
 }
 
-func (r *Runtime) createTypedArrayCtor(val *Object, ctor func(args []Value, newTarget, proto *Object) *Object, name unistring.String, bytesPerElement int) {
+func (r *Runtime) createTypedArrayCtor(val *Object, ctor func(args []Value, newTarget, proto *Object) *Object, name unistring.String, bytesPerElement int) *Object {
 	p := r.newBaseObject(r.getTypedArrayPrototype(), classObject)
 	o := r.newNativeConstructOnly(val, func(args []Value, newTarget *Object) *Object {
 		return ctor(args, newTarget, p.val)
@@ -1463,6 +1463,8 @@ func (r *Runtime) createTypedArrayCtor(val *Object, ctor func(args []Value, newT
 	bpe := intToValue(int64(bytesPerElement))
 	o._putProp("BYTES_PER_ELEMENT", bpe, false, false, false)
 	p._putProp("BYTES_PER_ELEMENT", bpe, false, false, false)
+
+	return p.val
 }
 
 func addTypedArrays(t *objectTemplate) {
@@ -1592,9 +1594,15 @@ func (r *Runtime) getUint8Array() *Object {
 	if ret == nil {
 		ret = &Object{runtime: r}
 		r.global.Uint8Array = ret
-		r.createTypedArrayCtor(ret, r.newUint8Array, "Uint8Array", 1)
+		p := r.createTypedArrayCtor(ret, r.newUint8Array, "Uint8Array", 1)
+		r.global.Uint8ArrayPrototype = p
 	}
 	return ret
+}
+
+func (r *Runtime) getUint8ArrayPrototype() *Object {
+	r.getUint8Array()
+	return r.global.Uint8ArrayPrototype
 }
 
 func (r *Runtime) getUint8ClampedArray() *Object {

--- a/runtime.go
+++ b/runtime.go
@@ -78,6 +78,8 @@ type global struct {
 	Float32Array      *Object
 	Float64Array      *Object
 
+	Uint8ArrayPrototype *Object
+
 	WeakSet *Object
 	WeakMap *Object
 	Map     *Object
@@ -1839,6 +1841,11 @@ func (r *Runtime) toValue(i interface{}, origValue reflect.Value) Value {
 		obj.self = m
 		m.init()
 		return obj
+	case []uint8:
+		buf := r._newArrayBuffer(r.getArrayBufferPrototype(), nil)
+		buf.data = i
+		arr := r.newUint8ArrayObject(buf, 0, len(i), r.getUint8ArrayPrototype())
+		return arr.val
 	case []interface{}:
 		return r.newObjectGoSlice(&i, false).val
 	case *[]interface{}:

--- a/typedarrays.go
+++ b/typedarrays.go
@@ -897,7 +897,6 @@ func (r *Runtime) _newTypedArrayObject(buf *arrayBufferObject, offset, length, e
 	o.self = a
 	a.init()
 	return a
-
 }
 
 func (r *Runtime) newUint8ArrayObject(buf *arrayBufferObject, offset, length int, proto *Object) *typedArrayObject {

--- a/typedarrays_test.go
+++ b/typedarrays_test.go
@@ -23,6 +23,30 @@ func TestUint16ArrayObject(t *testing.T) {
 	}
 }
 
+func TestUint8ArrayConversion(t *testing.T) {
+	vm := New()
+	data := []byte{0xAA, 0xBB}
+	vm.Set("a", data)
+	_, err := vm.RunString(`
+	if (a.length !== 2 || a[0] !== 0xAA || a[1] !== 0xBB) {
+		throw new Error(a);
+	}
+	`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ret, err := vm.RunString(`
+	Uint8Array.of(0xCC, 0xDD);
+	`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data1 := ret.Export().([]byte)
+	if len(data1) != 2 || data1[0] != 0xCC || data1[1] != 0xDD {
+		t.Fatal(data1)
+	}
+}
+
 func TestArrayBufferGoWrapper(t *testing.T) {
 	vm := New()
 	data := []byte{0xAA, 0xBB}


### PR DESCRIPTION
Turns `[]uint8` into `Uint8Array` instead of a go array proxy.