### PR TITLE
Check obj value before call ToObject to get prototype

### DIFF
--- a/builtin_object.go
+++ b/builtin_object.go
@@ -20,7 +20,11 @@ func (r *Runtime) builtin_Object(args []Value, newTarget *Object) *Object {
 }
 
 func (r *Runtime) object_getPrototypeOf(call FunctionCall) Value {
-	o := call.Argument(0).ToObject(r)
+	t := call.Argument(0)
+	if t == _null || t == _undefined {
+		return _null
+	}
+	o := t.ToObject(r)
 	p := o.self.proto()
 	if p == nil {
 		return _null


### PR DESCRIPTION
See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getPrototypeOf#return_value

In current state, If the obj is null it will throw an error when we call ToObject.

[value.go#L425](https://github.com/dop251/goja/blob/ccbae20bcec2479301d0c65d4ff66f1f5d6becf4/value.go#L425)
```go
func (n valueNull) ToObject(r *Runtime) *Object {
	r.typeErrorResult(true, "Cannot convert undefined or null to object")
	return nil
	//return r.newObject()
}
```

Instead of that, We just check the obj before to call ToObject to avoid the error.

[builtin_object.go#L22](https://github.com/dop251/goja/blob/ccbae20bcec2479301d0c65d4ff66f1f5d6becf4/builtin_object.go#L22)
```diff
func (r *Runtime) object_getPrototypeOf(call FunctionCall) Value {
-	 o := call.Argument(0).ToObject(r)
+	 t := call.Argument(0)
+	 if t == _null || t == _undefined {
+		return _null
+	 }
+	 o := t.ToObject(r)
	 p := o.self.proto()
	 if p == nil {
	 	return _null
	 }
	 return p
}
```