### PR TITLE
Allow access to the public fields of unexported embedded struct

### DIFF
--- a/object_goreflect.go
+++ b/object_goreflect.go
@@ -535,14 +535,17 @@ func (r *Runtime) buildFieldInfo(t reflect.Type, index []int, info *reflectField
 	for i := 0; i < n; i++ {
 		field := t.Field(i)
 		name := field.Name
-		if !ast.IsExported(name) {
+		isExported := ast.IsExported(name)
+
+		if !isExported && !field.Anonymous {
 			continue
 		}
+
 		if r.fieldNameMapper != nil {
 			name = r.fieldNameMapper.FieldName(t, field)
 		}
 
-		if name != "" {
+		if name != "" && isExported {
 			if inf, exists := info.Fields[name]; !exists {
 				info.Names = append(info.Names, name)
 			} else {
@@ -557,7 +560,7 @@ func (r *Runtime) buildFieldInfo(t reflect.Type, index []int, info *reflectField
 			copy(idx, index)
 			idx[len(idx)-1] = i
 
-			if name != "" {
+			if name != "" && isExported {
 				info.Fields[name] = reflectFieldInfo{
 					Index:     idx,
 					Anonymous: field.Anonymous,


### PR DESCRIPTION
This is a small change to allow accessing the public fields of unexported embedded struct. For example:

```go
type base struct {
    Name string
}

type Foo struct {
    base
}

vm := goja.New()
vm.Set("foo", Foo{base{Name: "test"}})
vm.RunString("foo.Name") // currently prints undefined, expected "test"
```