### PR TITLE
Separators for numeric literals

### DIFF
--- a/parser/expression.go
+++ b/parser/expression.go
@@ -249,6 +249,11 @@ func (self *_parser) parseRegExpLiteral() *ast.RegExpLiteral {
 
 	literal := self.str[offset:endOffset]
 
+	// Unicode CodePoint sequence
+	if flags == "u" && strings.Contains(pattern, "_") {
+		self.error(offset, "Invalid Unicode escape sequence")
+	}
+
 	return &ast.RegExpLiteral{
 		Idx:     idx,
 		Literal: literal,

--- a/parser/lexer.go
+++ b/parser/lexer.go
@@ -633,8 +633,8 @@ func (self *_parser) skipWhiteSpace() {
 	}
 }
 
-func (self *_parser) scanMantissa(base int) {
-	for digitValue(self.chr) < base || self.chr == '_' {
+func (self *_parser) scanMantissa(base int, allowSeparator bool) {
+	for digitValue(self.chr) < base || (allowSeparator && self.chr == '_') {
 		afterUnderscore := self.chr == '_'
 		self.read()
 		if afterUnderscore && !isDigit(self.chr, base) {
@@ -1144,7 +1144,7 @@ func (self *_parser) scanNumericLiteral(decimalPoint bool) (token.Token, string)
 
 	if decimalPoint {
 		offset--
-		self.scanMantissa(10)
+		self.scanMantissa(10, true)
 	} else {
 		if self.chr == '0' {
 			self.read()
@@ -1160,7 +1160,7 @@ func (self *_parser) scanNumericLiteral(decimalPoint bool) (token.Token, string)
 				// no-op
 			default:
 				// legacy octal
-				self.scanMantissa(8)
+				self.scanMantissa(8, false)
 				goto end
 			}
 			if base > 0 {
@@ -1168,15 +1168,15 @@ func (self *_parser) scanNumericLiteral(decimalPoint bool) (token.Token, string)
 				if !isDigit(self.chr, base) {
 					return token.ILLEGAL, self.str[offset:self.chrOffset]
 				}
-				self.scanMantissa(base)
+				self.scanMantissa(base, true)
 				goto end
 			}
 		} else {
-			self.scanMantissa(10)
+			self.scanMantissa(10, true)
 		}
 		if self.chr == '.' {
 			self.read()
-			self.scanMantissa(10)
+			self.scanMantissa(10, true)
 		}
 	}
 
@@ -1187,7 +1187,7 @@ func (self *_parser) scanNumericLiteral(decimalPoint bool) (token.Token, string)
 		}
 		if isDecimalDigit(self.chr) {
 			self.read()
-			self.scanMantissa(10)
+			self.scanMantissa(10, true)
 		} else {
 			return token.ILLEGAL, self.str[offset:self.chrOffset]
 		}

--- a/parser/lexer.go
+++ b/parser/lexer.go
@@ -634,8 +634,12 @@ func (self *_parser) skipWhiteSpace() {
 }
 
 func (self *_parser) scanMantissa(base int) {
-	for digitValue(self.chr) < base {
+	for digitValue(self.chr) < base || self.chr == '_' {
+		afterUnderscore := self.chr == '_'
 		self.read()
+		if afterUnderscore && !isDigit(self.chr, base) {
+			self.error(self.chrOffset, "Only one underscore is allowed as numeric separator")
+		}
 	}
 }
 

--- a/parser/lexer_test.go
+++ b/parser/lexer_test.go
@@ -264,6 +264,11 @@ Second line \
 			token.NUMBER, "12.3", 5,
 		)
 
+		test("1_000 1_000_000",
+			token.NUMBER, "1_000", 1,
+			token.NUMBER, "1_000_000", 7,
+		)
+
 		test(`1n`,
 			token.NUMBER, "1n", 1,
 		)

--- a/string_ascii.go
+++ b/string_ascii.go
@@ -205,6 +205,12 @@ func (s asciiString) ToNumber() Value {
 		return _negativeInf
 	}
 
+	// Go allows underscores in numbers, when parsed as floats,
+	// as in s._toFloat(), but JS expect them to be interpreted as NaN.
+	if strings.Contains(string(s), "_") {
+		return _NaN
+	}
+
 	if i, err := s._toInt(); err == nil {
 		return intToValue(i)
 	}

--- a/tc39_test.go
+++ b/tc39_test.go
@@ -227,7 +227,6 @@ var (
 		"Atomics.pause",
 		"FinalizationRegistry",
 		"WeakRef",
-		"numeric-separator-literal",
 		"__getter__",
 		"__setter__",
 		"ShadowRealm",


### PR DESCRIPTION
It adds support for separators (`_`) for numeric literals.

I did some tests using goja in a real-world scenario, and the user experience looks good, but I have some comments for which I'd like to get your input (cc/ @dop251):
- In case there's two (or more) consecutive separators, it adds an error, with the same error message as Deno and NodeJS, for consistency. _Is it okay?_ _Or should I early stop and/or return an ILLEGAL token instead?_ 
- I haven't dropped the separators, because Go has support for it, so it can later parse the string as a number. 
_Is that fine? Or do you prefer separators to be dropped from the parsed token?_

Thanks! 🙇🏻 