### PR TITLE
Add Runtime.SetGlobalObject() method.

### DIFF
--- a/runtime.go
+++ b/runtime.go
@@ -2377,6 +2377,12 @@ func (r *Runtime) GlobalObject() *Object {
 	return r.globalObject
 }
 
+// SetGlobalObject sets the global object to the given object.
+// Note, any existing references to the previous global object will continue to reference that object.
+func (r *Runtime) SetGlobalObject(object *Object) {
+	r.globalObject = object
+}
+
 // Set the specified variable in the global context.
 // Equivalent to running "name = value" in non-strict mode.
 // The value is first converted using ToValue().


### PR DESCRIPTION
See https://github.com/dop251/goja/discussions/653#discussioncomment-11952311.

I'm not sure if there should be more to go along with this, this bare minimum function makes sense in the above Proxy example, but if you're actually setting it to a new object rather than Proxying the old global, all the built-ins will be missing from the global scope. Maybe that is desirable in some situations, but maybe another function to initialize a "default" global object makes sense as well?

I added tests for all the cases that seemed notable, things like variables being defined/undefined in old/new global, and checking references to the old global in the new global scope. I also included a test for the original Proxy example to make sure it worked as expected.