### PR TITLE
Ignore source map parse errors

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -53,6 +53,7 @@ const (
 
 type options struct {
 	disableSourceMaps bool
+	skipEmptySourceMaps bool
 	sourceMapLoader   func(path string) ([]byte, error)
 }
 
@@ -64,6 +65,13 @@ type Option func(*options)
 // are not in use.
 func WithDisableSourceMaps(opts *options) {
 	opts.disableSourceMaps = true
+}
+
+// WithSkipEmptySourceMaps is an option to ignore source maps that are empty rather than fail parsing.
+// This is particulary useful for code compiled from TypeScript. The TypeScript compiler outputs empty
+// source maps for files containing only type definitions.
+func WithSkipEmptySourceMaps(opts *options) {
+	opts.skipEmptySourceMaps = true
 }
 
 // WithSourceMapLoader is an option to set a custom source map loader. The loader will be given a path or a

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -53,7 +53,6 @@ const (
 
 type options struct {
 	disableSourceMaps bool
-	skipEmptySourceMaps bool
 	sourceMapLoader   func(path string) ([]byte, error)
 }
 
@@ -65,13 +64,6 @@ type Option func(*options)
 // are not in use.
 func WithDisableSourceMaps(opts *options) {
 	opts.disableSourceMaps = true
-}
-
-// WithSkipEmptySourceMaps is an option to ignore source maps that are empty rather than fail parsing.
-// This is particulary useful for code compiled from TypeScript. The TypeScript compiler outputs empty
-// source maps for files containing only type definitions.
-func WithSkipEmptySourceMaps(opts *options) {
-	opts.skipEmptySourceMaps = true
 }
 
 // WithSourceMapLoader is an option to set a custom source map loader. The loader will be given a path or a

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1241,6 +1241,25 @@ var x = {};
 		is(err, nil)
 		is(count, 1)
 		is(requestedPath, "https://site.com/delme.js.map")
+
+		// Checks related to empty source maps.
+		emptySourceMapLoader := func(p string) ([]byte, error) {
+			count++
+			requestedPath = p
+			emptySourceMap := `{"version":3,"file":"delme.js","sourceRoot":"","sources":["../src/delme.ts"],"names":[],"mappings":""}`
+			return []byte(emptySourceMap), nil
+		}
+
+		// First, ensure that the expected error is produced for an empty source map.
+		_, err = ParseFile(nil, "delme.js", src, 0, WithSourceMapLoader(emptySourceMapLoader))
+		is(true, strings.Contains(err.Error(), errSourceMapEmptyString))
+
+		// Then, ensure WithSkipEmptySourceMaps bypasses the error.
+		count = 0
+		_, err = ParseFile(nil, "delme.js", src, 0, WithSourceMapLoader(emptySourceMapLoader), WithSkipEmptySourceMaps)
+		is(err, nil)
+		is(count, 1)
+		is(requestedPath, "delme.js.map")
 	})
 }
 

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1250,13 +1250,9 @@ var x = {};
 			return []byte(emptySourceMap), nil
 		}
 
-		// First, ensure that the expected error is produced for an empty source map.
-		_, err = ParseFile(nil, "delme.js", src, 0, WithSourceMapLoader(emptySourceMapLoader))
-		is(true, strings.Contains(err.Error(), errSourceMapEmptyString))
-
-		// Then, ensure WithSkipEmptySourceMaps bypasses the error.
+		// Ensure empty source map errors are skipped
 		count = 0
-		_, err = ParseFile(nil, "delme.js", src, 0, WithSourceMapLoader(emptySourceMapLoader), WithSkipEmptySourceMaps)
+		_, err = ParseFile(nil, "delme.js", src, 0, WithSourceMapLoader(emptySourceMapLoader))
 		is(err, nil)
 		is(count, 1)
 		is(requestedPath, "delme.js.map")

--- a/parser/statement.go
+++ b/parser/statement.go
@@ -12,6 +12,11 @@ import (
 	"github.com/go-sourcemap/sourcemap"
 )
 
+const (
+	// Copied from https://github.com/go-sourcemap/sourcemap/blob/794171861aeb0f83fcd66eeb0415a5062594cde6/mappings.go#L35
+	errSourceMapEmptyString = "sourcemap: mappings are empty"
+)
+
 func (self *_parser) parseBlockStatement() *ast.BlockStatement {
 	node := &ast.BlockStatement{}
 	node.LeftBrace = self.expect(token.LEFT_BRACE)
@@ -950,6 +955,8 @@ func (self *_parser) parseSourceMap() *sourcemap.Consumer {
 
 		if sm, err := sourcemap.Parse(self.file.Name(), data); err == nil {
 			return sm
+		} else if self.opts.skipEmptySourceMaps && strings.Contains(err.Error(), errSourceMapEmptyString) {
+			return nil
 		} else {
 			self.error(file.Idx(0), "Could not parse source map: %v", err)
 		}

--- a/parser/statement.go
+++ b/parser/statement.go
@@ -12,11 +12,6 @@ import (
 	"github.com/go-sourcemap/sourcemap"
 )
 
-const (
-	// Copied from https://github.com/go-sourcemap/sourcemap/blob/794171861aeb0f83fcd66eeb0415a5062594cde6/mappings.go#L35
-	errSourceMapEmptyString = "sourcemap: mappings are empty"
-)
-
 func (self *_parser) parseBlockStatement() *ast.BlockStatement {
 	node := &ast.BlockStatement{}
 	node.LeftBrace = self.expect(token.LEFT_BRACE)
@@ -955,10 +950,8 @@ func (self *_parser) parseSourceMap() *sourcemap.Consumer {
 
 		if sm, err := sourcemap.Parse(self.file.Name(), data); err == nil {
 			return sm
-		} else if strings.Contains(err.Error(), errSourceMapEmptyString) {
-			return nil
 		} else {
-			self.error(file.Idx(0), "Could not parse source map: %v", err)
+			return nil
 		}
 	}
 	return nil

--- a/parser/statement.go
+++ b/parser/statement.go
@@ -941,7 +941,6 @@ func (self *_parser) parseSourceMap() *sourcemap.Consumer {
 		}
 
 		if err != nil {
-			self.error(file.Idx(0), "Could not load source map: %v", err)
 			return nil
 		}
 		if data == nil {

--- a/parser/statement.go
+++ b/parser/statement.go
@@ -955,7 +955,7 @@ func (self *_parser) parseSourceMap() *sourcemap.Consumer {
 
 		if sm, err := sourcemap.Parse(self.file.Name(), data); err == nil {
 			return sm
-		} else if self.opts.skipEmptySourceMaps && strings.Contains(err.Error(), errSourceMapEmptyString) {
+		} else if strings.Contains(err.Error(), errSourceMapEmptyString) {
 			return nil
 		} else {
 			self.error(file.Idx(0), "Could not parse source map: %v", err)


### PR DESCRIPTION
The TypeScript compiler produces empty source map files for source files containing only type definitions. This PR updates goja to ignore source map parse errors, matching the nodejs and browser behavior.

The empty source map error is produced [here](https://github.com/go-sourcemap/sourcemap/blob/794171861aeb0f83fcd66eeb0415a5062594cde6/mappings.go#L35).