### PR TITLE
Fix the subarray set method

### DIFF
--- a/builtin_typedarrays.go
+++ b/builtin_typedarrays.go
@@ -1060,8 +1060,8 @@ func (r *Runtime) typedArrayProto_set(call FunctionCall) Value {
 			}
 			for i := 0; i < srcLen; i++ {
 				val := nilSafe(srcObj.self.getIdx(valueInt(i), nil))
-				if ta.isValidIntegerIndex(i) {
-					ta.typedArray.set(targetOffset+i, val)
+				if ta.isValidIntegerIndex(targetOffset + i) {
+					ta.typedArray.set(ta.offset+targetOffset+i, val)
 				}
 			}
 		}

--- a/builtin_typedarrays_test.go
+++ b/builtin_typedarrays_test.go
@@ -367,3 +367,19 @@ func TestDataViewExportToBytes(t *testing.T) {
 		t.Fatal("unexpected value", b)
 	}
 }
+
+func TestTypedArraySubarraySet(t *testing.T) {
+	const SCRIPT = `
+	const u = new Uint8Array(4)
+	const s = u.subarray(1, 4);
+	s.set([1,2,3], 0);
+	if (s.length !== 3) {
+		throw new Error("s.length=" + s.length + ", expected 3");
+	}
+	if (s[0] !== 1 || s[1] !== 2 || s[2] !== 3) {
+		throw new Error("s=[" + s.join(",") + "], expected [1,2,3]");
+	}
+	`
+
+	testScript(SCRIPT, _undefined, t)
+}


### PR DESCRIPTION
# What

In the `arrayObject` path, the `set` method expects an absolute buffer index including the array's offset, just like in the `typedArrayObject` which has a var `dstOffset`. This PR ensures that this has been taken into account for `arrayObject`.

Closes: https://github.com/dop251/goja/issues/686