### PR TITLE
Reduce allocation overhead in hot paths

### DIFF
--- a/builtin_function.go
+++ b/builtin_function.go
@@ -126,8 +126,18 @@ func (r *Runtime) boundCallable(target func(FunctionCall) Value, boundArgs []Val
 	} else {
 		this = _undefined
 	}
+	if len(args) == 0 {
+		return func(call FunctionCall) Value {
+			return target(FunctionCall{
+				This:      this,
+				Arguments: call.Arguments,
+			})
+		}
+	}
 	return func(call FunctionCall) Value {
-		a := append(args, call.Arguments...)
+		a := make([]Value, len(args)+len(call.Arguments))
+		copy(a, args)
+		copy(a[len(args):], call.Arguments)
 		return target(FunctionCall{
 			This:      this,
 			Arguments: a,
@@ -144,8 +154,18 @@ func (r *Runtime) boundConstruct(f *Object, target func([]Value, *Object) *Objec
 		args = make([]Value, len(boundArgs)-1)
 		copy(args, boundArgs[1:])
 	}
+	if len(args) == 0 {
+		return func(fargs []Value, newTarget *Object) *Object {
+			if newTarget == f {
+				newTarget = nil
+			}
+			return target(fargs, newTarget)
+		}
+	}
 	return func(fargs []Value, newTarget *Object) *Object {
-		a := append(args, fargs...)
+		a := make([]Value, len(args)+len(fargs))
+		copy(a, args)
+		copy(a[len(args):], fargs)
 		if newTarget == f {
 			newTarget = nil
 		}

--- a/value.go
+++ b/value.go
@@ -57,7 +57,7 @@ var (
 	reflectTypeError    = reflect.TypeOf((*error)(nil)).Elem()
 )
 
-var intCache [256]Value
+var intCache [512]Value
 
 // Value represents an ECMAScript value.
 //
@@ -1193,7 +1193,7 @@ func typeErrorResult(throw bool, args ...interface{}) {
 }
 
 func init() {
-	for i := 0; i < 256; i++ {
+	for i := 0; i < 512; i++ {
 		intCache[i] = valueInt(i - 256)
 	}
 }

--- a/vm.go
+++ b/vm.go
@@ -390,7 +390,7 @@ type instruction interface {
 }
 
 func intToValue(i int64) Value {
-	if idx := 256 + i; idx >= 0 && idx < 256 {
+	if idx := 256 + i; idx >= 0 && idx < 512 {
 		return intCache[idx]
 	}
 	if i >= -maxInt && i <= maxInt {
@@ -603,6 +603,9 @@ func (vm *vm) init() {
 	vm.sb = -1
 	vm.stash = &vm.r.global.stash
 	vm.maxCallStackSize = math.MaxInt32
+	if vm.callStack == nil {
+		vm.callStack = make([]context, 0, 64)
+	}
 }
 
 func (vm *vm) halted() bool {


### PR DESCRIPTION
- Expand intCache from [-256, -1] to [-256, 255] so common positive integers (0, 1, 2, array indices, loop counters) are served from a pre-allocated cache instead of triggering runtime.convT64 boxing.

- Fix boundCallable/boundConstruct to use make+copy instead of append, which could mutate the shared args backing array. Add a fast path for the common case of no bound arguments.

- Pre-allocate callStack with capacity 64 to avoid repeated slice growth during early function calls.