### PR TITLE
Fix TypedArray.prototype.with and toReversed with non-zero byte offset

### DIFF
--- a/builtin_typedarrays.go
+++ b/builtin_typedarrays.go
@@ -1241,7 +1241,7 @@ func (r *Runtime) typedArrayProto_with(call FunctionCall) Value {
 		} else {
 			fromValue = ta.typedArray.get(ta.offset + k)
 		}
-		a.typedArray.set(ta.offset+k, fromValue)
+		a.typedArray.set(k, fromValue)
 	}
 	return a.val
 }
@@ -1260,7 +1260,7 @@ func (r *Runtime) typedArrayProto_toReversed(call FunctionCall) Value {
 	for k := 0; k < length; k++ {
 		from := length - k - 1
 		fromValue := ta.typedArray.get(ta.offset + from)
-		a.typedArray.set(ta.offset+k, fromValue)
+		a.typedArray.set(k, fromValue)
 	}
 
 	return a.val

--- a/builtin_typedarrays_test.go
+++ b/builtin_typedarrays_test.go
@@ -383,3 +383,27 @@ func TestTypedArraySubarraySet(t *testing.T) {
 
 	testScript(SCRIPT, _undefined, t)
 }
+
+func TestTypedArrayWithOffset(t *testing.T) {
+	const SCRIPT = `
+	var buf = new ArrayBuffer(16);
+	var src = new Uint8Array(buf, 4, 4);
+	src[0] = 10; src[1] = 20; src[2] = 30; src[3] = 40;
+	var result = src.with(1, 99);
+	result[0] === 10 && result[1] === 99 && result[2] === 30 && result[3] === 40
+		&& result.length === 4 && src[1] === 20;
+	`
+	testScript(SCRIPT, valueTrue, t)
+}
+
+func TestTypedArrayToReversedOffset(t *testing.T) {
+	const SCRIPT = `
+	var buf = new ArrayBuffer(16);
+	var src = new Uint8Array(buf, 4, 4);
+	src[0] = 10; src[1] = 20; src[2] = 30; src[3] = 40;
+	var result = src.toReversed();
+	result[0] === 40 && result[1] === 30 && result[2] === 20 && result[3] === 10
+		&& result.length === 4 && src[0] === 10;
+	`
+	testScript(SCRIPT, valueTrue, t)
+}


### PR DESCRIPTION
When a TypedArray view is created with a non-zero byte offset, with() and toReversed() were incorrectly applying the source offset when writing to the destination array. The destination is always a newly created TypedArray with offset 0, so writes should use the plain index k, not ta.offset+k.