### PR TITLE
Add PromiseJobEnqueuer hook and RunPromiseJob for external microtask scheduling

### DIFF
--- a/builtin_promise.go
+++ b/builtin_promise.go
@@ -28,6 +28,25 @@ const (
 
 type PromiseRejectionTracker func(p *Promise, operation PromiseRejectionOperation)
 
+// PromiseJobEnqueuer is a host hook that receives promise jobs instead of
+// queueing them internally (ECMA-262 HostEnqueuePromiseJob). The host is
+// responsible for invoking each job in FIFO order via RunPromiseJob.
+//
+// The hook runs on the runtime's goroutine. Jobs should be captured and run
+// via RunPromiseJob only after the current turn (RunString/RunProgram) returns.
+// Synchronous invocation from within the hook is supported but does not
+// preserve ECMA-262 turn ordering.
+//
+// If set while jobs are already pending in the internal queue, they are
+// forwarded to the hook when the current turn exits. Jobs enqueued after the
+// hook is set are delivered directly during the turn, so they reach the hook
+// before the forwarded (older) jobs. Install the enqueuer before enqueuing any
+// jobs if global FIFO ordering is required.
+//
+// Set to nil (the default) to restore the internal queue.
+// Register via Runtime.SetPromiseJobEnqueuer.
+type PromiseJobEnqueuer func(job func())
+
 type jobCallback struct {
 	callback func(FunctionCall) Value
 }
@@ -38,11 +57,12 @@ type promiseCapability struct {
 }
 
 type promiseReaction struct {
-	capability  *promiseCapability
-	typ         promiseReactionType
-	handler     *jobCallback
-	asyncRunner *asyncRunner
-	asyncCtx    interface{}
+	capability   *promiseCapability
+	typ          promiseReactionType
+	handler      *jobCallback
+	asyncRunner  *asyncRunner
+	asyncCtx     interface{}
+	asyncTracker AsyncContextTracker
 }
 
 var typePromise = reflect.TypeOf((*Promise)(nil))
@@ -154,7 +174,9 @@ func (p *Promise) addReactions(fulfillReaction *promiseReaction, rejectReaction 
 	if tracker := r.asyncContextTracker; tracker != nil {
 		ctx := tracker.Grab()
 		fulfillReaction.asyncCtx = ctx
+		fulfillReaction.asyncTracker = tracker
 		rejectReaction.asyncCtx = ctx
+		rejectReaction.asyncTracker = tracker
 	}
 	switch p.state {
 	case PromiseStatePending:
@@ -187,7 +209,20 @@ func (r *Runtime) newPromiseResolveThenableJob(p *Promise, thenable Value, then 
 }
 
 func (r *Runtime) enqueuePromiseJob(job func()) {
+	// While a tracker scope is active (between Resumed and Exited in
+	// newPromiseReactionJob), buffer jobs internally instead of delivering
+	// them to a synchronous hook. A synchronous hook calling RunPromiseJob
+	// would run the new reaction while the outer tracker is still resumed,
+	// causing nested Resumed() calls. Once buffered jobs exist, later jobs
+	// are also buffered to preserve FIFO.
+	if hook := r.promiseJobEnqueuer; hook != nil && !r.asyncTrackerActive && !r.promiseJobQueuePriority {
+		hook(job)
+		return
+	}
 	r.jobQueue = append(r.jobQueue, job)
+	if r.asyncTrackerActive {
+		r.promiseJobQueuePriority = true
+	}
 }
 
 func (r *Runtime) triggerPromiseReactions(reactions []*promiseReaction, argument Value) {
@@ -200,15 +235,39 @@ func (r *Runtime) newPromiseReactionJob(reaction *promiseReaction, argument Valu
 	return func() {
 		var handlerResult Value
 		fulfill := false
+		// Set up the tracker before checking for a handler so that
+		// nil-handler propagation reactions also observe the
+		// Grab/Resumed/Exited invariant.
+		var tracker AsyncContextTracker
+		var exited bool
+		exitTracker := func() {
+			if tracker != nil && !exited {
+				exited = true
+				defer func() {
+					r.asyncTrackerActive = false
+				}()
+				tracker.Exited()
+			}
+		}
+		if t := reaction.asyncTracker; t != nil {
+			tracker = t
+			r.asyncTrackerActive = true
+			resumed := false
+			defer func() {
+				if !resumed {
+					r.asyncTrackerActive = false
+				}
+			}()
+			tracker.Resumed(reaction.asyncCtx)
+			resumed = true
+			defer exitTracker()
+		}
 		if reaction.handler == nil {
 			handlerResult = argument
 			if reaction.typ == promiseReactionFulfill {
 				fulfill = true
 			}
 		} else {
-			if tracker := r.asyncContextTracker; tracker != nil {
-				tracker.Resumed(reaction.asyncCtx)
-			}
 			ex := r.vm.try(func() {
 				handlerResult = r.callJobCallback(reaction.handler, _undefined, argument)
 				fulfill = true
@@ -216,9 +275,25 @@ func (r *Runtime) newPromiseReactionJob(reaction *promiseReaction, argument Valu
 			if ex != nil {
 				handlerResult = ex.val
 			}
-			if tracker := r.asyncContextTracker; tracker != nil {
-				tracker.Exited()
-			}
+		}
+		// Call Exited before resolving/rejecting the capability so the
+		// tracker brackets only the handler, not downstream resolution
+		// (thenable assimilation, reaction triggering). The defer above
+		// is a safety net for panics that skip this call.
+		//
+		// asyncTrackerActive stays true until Exited() returns so that
+		// promise work enqueued by Exited() itself is buffered rather
+		// than delivered to a synchronous hook.
+		exitTracker()
+		if tracker != nil && len(r.jobQueue) > 0 {
+			// Keep hook delivery paused through capability resolution
+			// so downstream reactions are appended behind the buffered
+			// jobs instead of overtaking them.
+			previousAsyncTrackerActive := r.asyncTrackerActive
+			r.asyncTrackerActive = true
+			defer func() {
+				r.asyncTrackerActive = previousAsyncTrackerActive
+			}()
 		}
 		if reaction.capability != nil {
 			if fulfill {
@@ -643,8 +718,19 @@ func (r *Runtime) SetPromiseRejectionTracker(tracker PromiseRejectionTracker) {
 }
 
 // SetAsyncContextTracker registers a handler that allows to track async execution contexts. See AsyncContextTracker
-// documentation for more details. Setting it to nil disables the functionality.
+// documentation for more details.
+//
+// Changing or clearing the tracker affects only reactions scheduled after the change.
+// Pending reactions retain the tracker that was active when they were scheduled.
+//
 // This method (as Runtime in general) is not goroutine-safe.
 func (r *Runtime) SetAsyncContextTracker(tracker AsyncContextTracker) {
 	r.asyncContextTracker = tracker
+}
+
+// SetPromiseJobEnqueuer registers a hook that receives promise jobs instead of
+// queueing them internally. See PromiseJobEnqueuer for the contract. nil
+// restores the default behaviour. Not goroutine-safe (except Interrupt).
+func (r *Runtime) SetPromiseJobEnqueuer(enqueuer PromiseJobEnqueuer) {
+	r.promiseJobEnqueuer = enqueuer
 }

--- a/func.go
+++ b/func.go
@@ -37,11 +37,21 @@ var (
 // AsyncContextTracker is a handler that allows to track an async execution context to ensure it remains
 // consistent across all callback invocations.
 // Whenever a Promise reaction job is scheduled the Grab method is called. It is supposed to return the
-// current context. The same context will be supplied to the Resumed method before the reaction job is
-// executed. The Exited method is called after the reaction job is finished.
+// current context. The same context will be supplied to the Resumed method before the reaction handler
+// is invoked. The Exited method is called after the reaction handler returns or throws, but before the
+// derived promise's capability is resolved or rejected, so the tracker does not span downstream resolution
+// (thenable assimilation, reaction triggering).
 // This means that for each invocation of the Grab method there will be exactly one subsequent invocation
 // of Resumed and then Exited methods (assuming the Promise is fulfilled or rejected). Also, the Resumed/Exited
 // calls cannot be nested, so Exited can simply clear the current context instead of popping from a stack.
+//
+// The tracker is captured at reaction scheduling time. If the tracker is replaced or cleared after a
+// reaction is scheduled but before it runs, the pending reaction still uses the tracker that was active
+// when it was scheduled.
+//
+// Resumed and Exited are called for all reaction types, including nil-handler propagation reactions
+// (e.g. Promise.resolve(1).then()).
+//
 // Note, this works for both async functions and regular Promise.then()/Promise.catch() callbacks.
 // See TestAsyncContextTracker for more insight.
 //

--- a/func_test.go
+++ b/func_test.go
@@ -1881,6 +1881,43 @@ func TestPromiseJobEnqueuer(t *testing.T) {
 			t.Fatalf("expected tracker-enqueued job to precede downstream reaction [1 2], got %v", order)
 		}
 	})
+
+	// A hook that panics during abrupt shutdown must not escape
+	// leaveAbrupt as a raw panic; RunProgram still returns the
+	// original InterruptedError and the runtime stays reusable.
+	t.Run("leaveabrupt-hook-panic-state-consistency", func(t *testing.T) {
+		r := New()
+		sentinel := errors.New("hook bug")
+		r.Set("mark", func() {})
+		r.Set("installPanickingHookAndInterrupt", func() {
+			r.SetPromiseJobEnqueuer(func(job func()) { panic(sentinel) })
+			r.Interrupt("trigger-abrupt")
+		})
+
+		_, err := r.RunString(`
+			Promise.resolve().then(function() { mark(); });
+			installPanickingHookAndInterrupt();
+		`)
+		if err == nil {
+			t.Fatal("expected InterruptedError from RunString, got nil")
+		}
+		if _, ok := err.(*InterruptedError); !ok {
+			t.Fatalf("expected *InterruptedError, got %T: %v", err, err)
+		}
+
+		if r.vm.stack != nil {
+			t.Fatal("vm.stack should be nil after leaveAbrupt hook panic")
+		}
+		if r.vm.prg != nil {
+			t.Fatal("vm.prg should be nil after leaveAbrupt hook panic")
+		}
+		if r.vm.sb != -1 {
+			t.Fatalf("vm.sb should be -1, got %d", r.vm.sb)
+		}
+		if _, err := r.RunString(`1 + 1`); err != nil {
+			t.Fatalf("runtime not reusable after hook panic: %v", err)
+		}
+	})
 }
 
 func TestGeneratorReturnIterCleanup(t *testing.T) {

--- a/func_test.go
+++ b/func_test.go
@@ -205,6 +205,86 @@ func (s *testAsyncContextTracker) Exited() {
 	s.resumed = false
 }
 
+// countingAsyncContextTracker counts Grab/Resumed/Exited calls.
+type countingAsyncContextTracker struct {
+	grabbed  int
+	resumed  int
+	exited   int
+	exitFunc func() // if non-nil, called from Exited() instead of the default
+}
+
+func (t *countingAsyncContextTracker) Grab() interface{} {
+	t.grabbed++
+	return nil
+}
+
+func (t *countingAsyncContextTracker) Resumed(_ interface{}) {
+	t.resumed++
+}
+
+func (t *countingAsyncContextTracker) Exited() {
+	t.exited++
+	if t.exitFunc != nil {
+		t.exitFunc()
+	}
+}
+
+type exitedEnqueueTracker struct {
+	r        *Runtime
+	exiting  bool
+	enqueued bool
+}
+
+func (t *exitedEnqueueTracker) Grab() interface{} {
+	return nil
+}
+
+func (t *exitedEnqueueTracker) Resumed(interface{}) {
+	if t.exiting {
+		panic("Resumed called while Exited is still running")
+	}
+}
+
+func (t *exitedEnqueueTracker) Exited() {
+	if t.exiting {
+		panic("nested Exited call")
+	}
+	t.exiting = true
+	defer func() {
+		t.exiting = false
+	}()
+	if !t.enqueued {
+		t.enqueued = true
+		_, _ = t.r.RunString(`Promise.resolve().then(function () { markExitedEnqueued(); })`)
+	}
+}
+
+type resumedEnqueueTracker struct {
+	r        *Runtime
+	resuming bool
+	enqueued bool
+}
+
+func (t *resumedEnqueueTracker) Grab() interface{} {
+	return nil
+}
+
+func (t *resumedEnqueueTracker) Resumed(interface{}) {
+	if t.resuming {
+		panic("nested Resumed while Resumed is still running")
+	}
+	t.resuming = true
+	defer func() {
+		t.resuming = false
+	}()
+	if !t.enqueued {
+		t.enqueued = true
+		_, _ = t.r.RunString(`Promise.resolve().then(function () { markResumedEnqueued(); })`)
+	}
+}
+
+func (t *resumedEnqueueTracker) Exited() {}
+
 func TestAsyncContextTracker(t *testing.T) {
 	r := New()
 	var tracker testAsyncContextTracker
@@ -300,6 +380,1505 @@ func TestAsyncContextTracker(t *testing.T) {
 	`)
 		if err != nil {
 			t.Fatal(err)
+		}
+	})
+}
+
+func TestPromiseJobEnqueuer(t *testing.T) {
+	drainJobs := func(t *testing.T, r *Runtime, captured *[]func()) {
+		for len(*captured) > 0 {
+			jobs := *captured
+			*captured = nil
+			for _, job := range jobs {
+				if err := r.RunPromiseJob(job); err != nil {
+					t.Fatalf("RunPromiseJob: %v", err)
+				}
+			}
+		}
+	}
+
+	t.Run("hook-called", func(t *testing.T) {
+		r := New()
+		var called bool
+		r.SetPromiseJobEnqueuer(func(job func()) {
+			called = true
+		})
+		_, err := r.RunString(`Promise.resolve().then(() => {})`)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !called {
+			t.Fatal("hook was not called")
+		}
+	})
+
+	t.Run("FIFO-order", func(t *testing.T) {
+		r := New()
+		var order []int
+		var captured []func()
+		r.SetPromiseJobEnqueuer(func(job func()) {
+			captured = append(captured, job)
+		})
+		r.Set("push", func(v int) {
+			order = append(order, v)
+		})
+		_, err := r.RunString(`
+			Promise.resolve().then(() => push(1));
+			Promise.resolve().then(() => push(2));
+			Promise.resolve().then(() => push(3));
+		`)
+		if err != nil {
+			t.Fatal(err)
+		}
+		drainJobs(t, r, &captured)
+		if len(order) != 3 || order[0] != 1 || order[1] != 2 || order[2] != 3 {
+			t.Fatalf("expected [1 2 3], got %v", order)
+		}
+	})
+
+	t.Run("default-unchanged", func(t *testing.T) {
+		r := New()
+		var ran bool
+		r.Set("mark", func() { ran = true })
+		_, err := r.RunString(`Promise.resolve().then(() => mark())`)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !ran {
+			t.Fatal("default job queue was not drained")
+		}
+	})
+
+	t.Run("jobs-work-when-invoked-later", func(t *testing.T) {
+		r := New()
+		var result int
+		var captured []func()
+		r.SetPromiseJobEnqueuer(func(job func()) {
+			captured = append(captured, job)
+		})
+		r.Set("set", func(v int) { result = v })
+		_, err := r.RunString(`Promise.resolve().then(() => set(42))`)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if result != 0 {
+			t.Fatalf("job ran during RunString, result=%d", result)
+		}
+		if len(captured) != 1 {
+			t.Fatalf("expected 1 captured job, got %d", len(captured))
+		}
+		drainJobs(t, r, &captured)
+		if result != 42 {
+			t.Fatalf("expected result=42 after running job, got %d", result)
+		}
+	})
+
+	t.Run("nil-restores-default", func(t *testing.T) {
+		r := New()
+		var ran bool
+		var captured []func()
+		r.SetPromiseJobEnqueuer(func(job func()) {
+			captured = append(captured, job)
+		})
+		r.Set("mark", func() { ran = true })
+		_, err := r.RunString(`Promise.resolve().then(() => mark())`)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if ran {
+			t.Fatal("job ran during RunString with hook set")
+		}
+		r.SetPromiseJobEnqueuer(nil)
+		ran = false
+		_, err = r.RunString(`Promise.resolve().then(() => mark())`)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !ran {
+			t.Fatal("default behavior not restored after nil")
+		}
+	})
+
+	t.Run("async-await-compat", func(t *testing.T) {
+		r := New()
+		var result int
+		var captured []func()
+		r.SetPromiseJobEnqueuer(func(job func()) {
+			captured = append(captured, job)
+		})
+		r.Set("set", func(v int) { result = v })
+		_, err := r.RunString(`
+			async function f() {
+				var x = await 1;
+				return x + 41;
+			}
+			f().then(v => set(v));
+		`)
+		if err != nil {
+			t.Fatal(err)
+		}
+		drainJobs(t, r, &captured)
+		if result != 42 {
+			t.Fatalf("expected result=42, got %d", result)
+		}
+	})
+
+	t.Run("interrupt-recovery", func(t *testing.T) {
+		r := New()
+		var reached bool
+		var captured []func()
+		r.SetPromiseJobEnqueuer(func(job func()) {
+			captured = append(captured, job)
+		})
+		r.Set("mark", func() { reached = true })
+		_, err := r.RunString(`Promise.resolve().then(() => mark())`)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(captured) != 1 {
+			t.Fatalf("expected 1 captured job, got %d", len(captured))
+		}
+		r.Interrupt("test-interrupt")
+		err = r.RunPromiseJob(captured[0])
+		if err == nil {
+			t.Fatal("expected error from interrupted job")
+		}
+		if _, ok := err.(*InterruptedError); !ok {
+			t.Fatalf("expected *InterruptedError, got %T: %v", err, err)
+		}
+		if reached {
+			t.Fatal("job should not have completed")
+		}
+		_, err = r.RunString(`mark()`)
+		if err != nil {
+			t.Fatalf("runtime not reusable after interrupt: %v", err)
+		}
+		if !reached {
+			t.Fatal("runtime did not execute after ClearInterrupt")
+		}
+	})
+
+	t.Run("pending-interrupt-native-handler", func(t *testing.T) {
+		r := New()
+		var captured []func()
+		var reached bool
+
+		r.SetPromiseJobEnqueuer(func(job func()) {
+			captured = append(captured, job)
+		})
+		if err := r.Set("nativeHandler", func() {
+			reached = true
+		}); err != nil {
+			t.Fatal(err)
+		}
+
+		_, err := r.RunString(`Promise.resolve().then(nativeHandler)`)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(captured) != 1 {
+			t.Fatalf("expected 1 captured job, got %d", len(captured))
+		}
+
+		r.Interrupt("test-interrupt")
+		err = r.RunPromiseJob(captured[0])
+		if _, ok := err.(*InterruptedError); !ok {
+			t.Fatalf("expected RunPromiseJob to return *InterruptedError before running native handler under pending interrupt; got %T (%v), native handler reached=%v", err, err, reached)
+		}
+		if reached {
+			t.Fatal("native handler ran even though the interrupt was already pending")
+		}
+		_, err = r.RunString(`nativeHandler()`)
+		if err != nil {
+			t.Fatalf("runtime not reusable after interrupted RunPromiseJob: %v", err)
+		}
+		if !reached {
+			t.Fatal("runtime did not execute after interrupted RunPromiseJob cleanup")
+		}
+	})
+
+	t.Run("pending-interrupt-nil-handler-propagation", func(t *testing.T) {
+		r := New()
+		var captured []func()
+
+		r.SetPromiseJobEnqueuer(func(job func()) {
+			captured = append(captured, job)
+		})
+
+		_, err := r.RunString(`Promise.resolve(1).then()`)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(captured) != 1 {
+			t.Fatalf("expected 1 captured nil-handler propagation job, got %d", len(captured))
+		}
+
+		r.Interrupt("test-interrupt")
+		err = r.RunPromiseJob(captured[0])
+		if _, ok := err.(*InterruptedError); !ok {
+			t.Fatalf("expected RunPromiseJob to return *InterruptedError before nil-handler propagation under pending interrupt; got %T (%v)", err, err)
+		}
+		if _, err := r.RunString(`1 + 1`); err != nil {
+			t.Fatalf("runtime not reusable after interrupted nil-handler job: %v", err)
+		}
+	})
+
+	t.Run("stack-overflow-recovery", func(t *testing.T) {
+		r := New()
+		r.SetMaxCallStackSize(5)
+		var reached bool
+		var captured []func()
+		r.SetPromiseJobEnqueuer(func(job func()) {
+			captured = append(captured, job)
+		})
+		r.Set("mark", func() { reached = true })
+		_, err := r.RunString(`
+			Promise.resolve().then(function f() { f(); });
+		`)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(captured) != 1 {
+			t.Fatalf("expected 1 captured job, got %d", len(captured))
+		}
+		err = r.RunPromiseJob(captured[0])
+		if err == nil {
+			t.Fatal("expected error from stack overflow")
+		}
+		if _, ok := err.(*StackOverflowError); !ok {
+			t.Fatalf("expected *StackOverflowError, got %T: %v", err, err)
+		}
+		if reached {
+			t.Fatal("job should not have completed")
+		}
+		_, err = r.RunString(`mark()`)
+		if err != nil {
+			t.Fatalf("runtime not reusable after stack overflow: %v", err)
+		}
+		if !reached {
+			t.Fatal("runtime did not execute after stack overflow recovery")
+		}
+	})
+
+	t.Run("panic-reraise", func(t *testing.T) {
+		r := New()
+		sentinel := errors.New("not an uncatchable exception")
+		defer func() {
+			if x := recover(); x == nil {
+				t.Fatal("expected RunPromiseJob to re-panic, but it did not panic")
+			} else if x != sentinel {
+				t.Fatalf("expected re-panic with sentinel error, got %v (%T)", x, x)
+			}
+		}()
+		_ = r.RunPromiseJob(func() { panic(sentinel) })
+		t.Fatal("expected RunPromiseJob to re-panic")
+	})
+
+	t.Run("stack-cleared-no-promise", func(t *testing.T) {
+		r := New()
+		r.SetPromiseJobEnqueuer(func(job func()) {})
+		_, err := r.RunString(`1 + 1`)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if r.vm.stack != nil {
+			t.Fatalf("r.vm.stack should be nil after RunString with hook set, got len=%d", len(r.vm.stack))
+		}
+		if r.jobQueue != nil {
+			t.Fatalf("r.jobQueue should be nil after RunString with hook set, got len=%d", len(r.jobQueue))
+		}
+	})
+
+	t.Run("stack-cleared-with-promise", func(t *testing.T) {
+		r := New()
+		var captured []func()
+		r.SetPromiseJobEnqueuer(func(job func()) {
+			captured = append(captured, job)
+		})
+		_, err := r.RunString(`Promise.resolve().then(() => {}); 1 + 1`)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if r.vm.stack != nil {
+			t.Fatalf("r.vm.stack should be nil after RunString with hook set, got len=%d", len(r.vm.stack))
+		}
+		if r.jobQueue != nil {
+			t.Fatalf("r.jobQueue should be nil after RunString with hook set, got len=%d", len(r.jobQueue))
+		}
+		// Captured jobs must still work when drained.
+		drainJobs(t, r, &captured)
+	})
+
+	t.Run("stack-cleared-after-runpromisejob", func(t *testing.T) {
+		r := New()
+		var captured []func()
+		r.SetPromiseJobEnqueuer(func(job func()) {
+			captured = append(captured, job)
+		})
+		r.Set("set", func(v int) {})
+		_, err := r.RunString(`Promise.resolve().then(() => set(42))`)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(captured) != 1 {
+			t.Fatalf("expected 1 captured job, got %d", len(captured))
+		}
+		if err := r.RunPromiseJob(captured[0]); err != nil {
+			t.Fatalf("RunPromiseJob: %v", err)
+		}
+		if r.vm.stack != nil {
+			t.Fatalf("r.vm.stack should be nil after RunPromiseJob, got len=%d", len(r.vm.stack))
+		}
+	})
+
+	t.Run("stack-cleared-after-runpromisejob-error", func(t *testing.T) {
+		r := New()
+		var captured []func()
+		r.SetPromiseJobEnqueuer(func(job func()) {
+			captured = append(captured, job)
+		})
+		r.Set("mark", func() {})
+		_, err := r.RunString(`Promise.resolve().then(() => mark())`)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(captured) != 1 {
+			t.Fatalf("expected 1 captured job, got %d", len(captured))
+		}
+		r.Interrupt("test-interrupt")
+		err = r.RunPromiseJob(captured[0])
+		if err == nil {
+			t.Fatal("expected error from interrupted job")
+		}
+		if r.vm.stack != nil {
+			t.Fatalf("r.vm.stack should be nil after RunPromiseJob error, got len=%d", len(r.vm.stack))
+		}
+		if _, err := r.RunString(`1 + 1`); err != nil {
+			t.Fatalf("runtime not reusable after error: %v", err)
+		}
+	})
+
+	t.Run("stranded-jobs-forwarded", func(t *testing.T) {
+		r := New()
+		var order []int
+		var captured []func()
+		r.Set("installHook", func() {
+			r.SetPromiseJobEnqueuer(func(job func()) {
+				captured = append(captured, job)
+			})
+		})
+		r.Set("push", func(v int) {
+			order = append(order, v)
+		})
+		_, err := r.RunString(`
+			Promise.resolve().then(() => push(42));
+			installHook();
+		`)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(captured) != 1 {
+			t.Fatalf("expected 1 forwarded job, got %d", len(captured))
+		}
+		if r.jobQueue != nil {
+			t.Fatalf("r.jobQueue should be nil, got len=%d", len(r.jobQueue))
+		}
+		drainJobs(t, r, &captured)
+		if len(order) != 1 || order[0] != 42 {
+			t.Fatalf("expected order=[42], got %v", order)
+		}
+	})
+
+	t.Run("synchronous-hook", func(t *testing.T) {
+		r := New()
+		var result int
+		r.Set("set", func(v int) { result = v })
+		r.SetPromiseJobEnqueuer(func(job func()) {
+			r.RunPromiseJob(job)
+		})
+		_, err := r.RunString(`Promise.resolve(42).then(v => set(v))`)
+		if err != nil {
+			t.Fatalf("RunString: %v", err)
+		}
+		if result != 42 {
+			t.Fatalf("expected result=42, got %d", result)
+		}
+	})
+
+	t.Run("reentrant-go-callback", func(t *testing.T) {
+		r := New()
+		var captured []func()
+		r.SetPromiseJobEnqueuer(func(job func()) {
+			captured = append(captured, job)
+		})
+		_, err := r.RunString(`Promise.resolve().then(() => {})`)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(captured) != 1 {
+			t.Fatalf("expected 1 captured job, got %d", len(captured))
+		}
+
+		var jobRan bool
+		r.Set("runJob", func() {
+			if err := r.RunPromiseJob(captured[0]); err != nil {
+				t.Fatalf("RunPromiseJob from callback: %v", err)
+			}
+			jobRan = true
+		})
+		_, err = r.RunString(`runJob()`)
+		if err != nil {
+			t.Fatalf("RunString(runJob()): %v", err)
+		}
+		if !jobRan {
+			t.Fatal("job did not run")
+		}
+		if _, err := r.RunString(`1 + 1`); err != nil {
+			t.Fatalf("runtime not reusable: %v", err)
+		}
+	})
+
+	t.Run("synchronous-hook-interrupt", func(t *testing.T) {
+		r := New()
+		var reached bool
+		r.Set("mark", func() { reached = true })
+		r.SetPromiseJobEnqueuer(func(job func()) {
+			r.Interrupt("test-interrupt")
+			err := r.RunPromiseJob(job)
+			if _, ok := err.(*InterruptedError); !ok {
+				t.Fatalf("expected *InterruptedError, got %T: %v", err, err)
+			}
+		})
+		_, err := r.RunString(`Promise.resolve().then(() => mark())`)
+		if _, ok := err.(*InterruptedError); !ok {
+			t.Fatalf("expected *InterruptedError from RunString, got %T: %v", err, err)
+		}
+		if reached {
+			t.Fatal("job should not have completed")
+		}
+		if _, err := r.RunString(`mark()`); err != nil {
+			t.Fatalf("runtime not reusable after interrupt: %v", err)
+		}
+		if !reached {
+			t.Fatal("mark() did not run after recovery")
+		}
+	})
+
+	t.Run("leave-abrupt-forwards-stranded-jobs", func(t *testing.T) {
+		r := New()
+		var order []int
+		var captured []func()
+
+		r.Set("installHook", func() {
+			r.SetPromiseJobEnqueuer(func(job func()) {
+				captured = append(captured, job)
+			})
+		})
+		r.Set("push", func(v int) { order = append(order, v) })
+		r.Set("boom", func() { r.Interrupt("test-abrupt") })
+
+		_, err := r.RunString(`
+			Promise.resolve().then(() => push(42));
+			installHook();
+			boom();
+		`)
+		if _, ok := err.(*InterruptedError); !ok {
+			t.Fatalf("expected *InterruptedError, got %T: %v", err, err)
+		}
+		if len(captured) != 1 {
+			t.Fatalf("expected 1 forwarded stranded job, got %d", len(captured))
+		}
+		if r.jobQueue != nil {
+			t.Fatalf("r.jobQueue should be nil after leaveAbrupt, got len=%d", len(r.jobQueue))
+		}
+		if r.vm.stack != nil {
+			t.Fatalf("r.vm.stack should be nil after leaveAbrupt, got len=%d", len(r.vm.stack))
+		}
+		if err := r.RunPromiseJob(captured[0]); err != nil {
+			t.Fatalf("RunPromiseJob on forwarded stranded job: %v", err)
+		}
+		if len(order) != 1 || order[0] != 42 {
+			t.Fatalf("expected order=[42], got %v", order)
+		}
+	})
+
+	t.Run("leave-abrupt-clears-stack", func(t *testing.T) {
+		r := New()
+		r.Set("boom", func() { r.Interrupt("test-abrupt") })
+		_, err := r.RunString(`var x = { a: 1, b: 2, c: 3 }; boom();`)
+		if err == nil {
+			t.Fatal("expected InterruptedError")
+		}
+		if r.vm.stack != nil {
+			t.Fatalf("r.vm.stack should be nil after interrupt, got len=%d", len(r.vm.stack))
+		}
+	})
+
+	t.Run("tracker-exited-on-interrupt", func(t *testing.T) {
+		r := New()
+
+		var tracker testAsyncContextTracker
+		tracker.logFunc = t.Log
+		tracker.ctx = &testAsyncCtx{group: "g", refCount: 0}
+		r.SetAsyncContextTracker(&tracker)
+
+		var captured []func()
+		r.SetPromiseJobEnqueuer(func(job func()) {
+			captured = append(captured, job)
+		})
+		r.Set("boom", func() { r.Interrupt("test-interrupt") })
+
+		_, err := r.RunString(`Promise.resolve().then(() => { boom(); })`)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(captured) != 1 {
+			t.Fatalf("expected 1 captured job, got %d", len(captured))
+		}
+		err = r.RunPromiseJob(captured[0])
+		if _, ok := err.(*InterruptedError); !ok {
+			t.Fatalf("expected *InterruptedError, got %T: %v", err, err)
+		}
+		if tracker.resumed {
+			t.Fatal("tracker.resumed should be false; Exited() was not called")
+		}
+		if _, err := r.RunString(`1 + 1`); err != nil {
+			t.Fatalf("runtime not reusable after interrupt: %v", err)
+		}
+	})
+
+	// Reentrant RunPromiseJob with StackOverflowError. After handleThrow
+	// truncates callStack and the defer calls clearStack, the outer script
+	// can continue normally.
+	t.Run("reentrant-stack-overflow", func(t *testing.T) {
+		r := New()
+		r.SetMaxCallStackSize(10)
+		var hookErr error
+		r.SetPromiseJobEnqueuer(func(job func()) {
+			hookErr = r.RunPromiseJob(job)
+		})
+		_, err := r.RunString(`Promise.resolve().then(function f() { f(); })`)
+		if err != nil {
+			t.Fatalf("outer RunString should succeed after reentrant stack overflow recovery, got: %v", err)
+		}
+		if hookErr == nil {
+			t.Fatal("expected error from reentrant RunPromiseJob")
+		}
+		if _, ok := hookErr.(*StackOverflowError); !ok {
+			t.Fatalf("expected *StackOverflowError from RunPromiseJob, got %T: %v", hookErr, hookErr)
+		}
+		if _, err := r.RunString(`1 + 1`); err != nil {
+			t.Fatalf("runtime not reusable after stack overflow: %v", err)
+		}
+	})
+
+	// RunPromiseJob called via AssertFunction (runWrapped, not RunProgram).
+	t.Run("reentrant-from-assertfunction", func(t *testing.T) {
+		r := New()
+		var order []int
+		var captured []func()
+		r.SetPromiseJobEnqueuer(func(job func()) {
+			captured = append(captured, job)
+		})
+		r.Set("push", func(v int) { order = append(order, v) })
+		r.Set("runJob", func() {
+			if err := r.RunPromiseJob(captured[0]); err != nil {
+				t.Fatalf("RunPromiseJob from callback: %v", err)
+			}
+		})
+		// Compile a JS function expression that creates a promise
+		// reaction and then calls runJob() to drain it reentrantly.
+		p, err := Compile("", `(function() { Promise.resolve().then(function() { push(42) }); runJob(); })`, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		v, err := r.RunProgram(p)
+		if err != nil {
+			t.Fatal(err)
+		}
+		fn, ok := AssertFunction(v)
+		if !ok {
+			t.Fatal("expected function")
+		}
+		// Call via AssertFunction (uses runWrapped, not RunProgram).
+		_, err = fn(nil)
+		if err != nil {
+			t.Fatalf("AssertFunction call: %v", err)
+		}
+		if len(order) != 1 || order[0] != 42 {
+			t.Fatalf("expected order=[42], got %v", order)
+		}
+		if _, err := r.RunString(`1 + 1`); err != nil {
+			t.Fatalf("runtime not reusable: %v", err)
+		}
+	})
+
+	// Clearing the hook mid-job: subsequent jobs go to the internal queue
+	// and are drained by leave() on the next Run*() call.
+	t.Run("hook-replaced-mid-turn", func(t *testing.T) {
+		r := New()
+		var secondRan bool
+		var captured []func()
+		r.SetPromiseJobEnqueuer(func(job func()) {
+			captured = append(captured, job)
+		})
+		r.Set("mark", func() { secondRan = true })
+		r.Set("clearHook", func() { r.SetPromiseJobEnqueuer(nil) })
+		_, err := r.RunString(`Promise.resolve().then(function() { clearHook(); Promise.resolve().then(function() { mark() }); })`)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(captured) != 1 {
+			t.Fatalf("expected 1 captured job, got %d", len(captured))
+		}
+		// Run the first job: it clears the hook and enqueues a second
+		// reaction to the internal queue.
+		if err := r.RunPromiseJob(captured[0]); err != nil {
+			t.Fatalf("RunPromiseJob: %v", err)
+		}
+		if secondRan {
+			t.Fatal("second reaction should not have run yet")
+		}
+		if r.jobQueue == nil || len(r.jobQueue) == 0 {
+			t.Fatal("expected second reaction in internal queue")
+		}
+		// leave() should drain the internal queue on the next Run*() call.
+		if _, err := r.RunString(`1 + 1`); err != nil {
+			t.Fatalf("RunString: %v", err)
+		}
+		if !secondRan {
+			t.Fatal("second reaction was not drained by leave()")
+		}
+		if r.jobQueue != nil {
+			t.Fatalf("r.jobQueue should be nil after leave(), got len=%d", len(r.jobQueue))
+		}
+	})
+
+	// Deeply chained reactions drained through a synchronous hook.
+	t.Run("deep-chain-synchronous-drain", func(t *testing.T) {
+		r := New()
+		var result int
+		r.Set("set", func(v int) { result = v })
+		r.SetPromiseJobEnqueuer(func(job func()) {
+			if err := r.RunPromiseJob(job); err != nil {
+				t.Fatalf("RunPromiseJob in deep chain: %v", err)
+			}
+		})
+		const chainLen = 100
+		_, err := r.RunString(fmt.Sprintf(`
+			var p = Promise.resolve(0);
+			for (var i = 0; i < %d; i++) {
+				p = p.then(function(v) { return v + 1; });
+			}
+			p.then(function(v) { set(v); });
+		`, chainLen))
+		if err != nil {
+			t.Fatalf("RunString: %v", err)
+		}
+		if result != chainLen {
+			t.Fatalf("expected result=%d, got %d", chainLen, result)
+		}
+		if _, err := r.RunString(`1 + 1`); err != nil {
+			t.Fatalf("runtime not reusable: %v", err)
+		}
+	})
+
+	// Reaction on a settled promise must not execute during .then().
+	t.Run("turn-ordering-preserved", func(t *testing.T) {
+		r := New()
+		var log []int
+		var captured []func()
+		r.SetPromiseJobEnqueuer(func(job func()) {
+			captured = append(captured, job)
+		})
+		r.Set("push", func(v int) { log = append(log, v) })
+		_, err := r.RunString(`
+			var p = Promise.resolve(42);
+			p.then(() => push(1));
+			push(0);
+		`)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(log) != 1 || log[0] != 0 {
+			t.Fatalf("expected log=[0] during RunString, got %v", log)
+		}
+		drainJobs(t, r, &captured)
+		if len(log) != 2 || log[0] != 0 || log[1] != 1 {
+			t.Fatalf("expected log=[0 1] after drain, got %v", log)
+		}
+	})
+
+	// Multiple stranded jobs forwarded by leave() must arrive in FIFO order.
+	t.Run("fifo-stranded-jobs-forwarded", func(t *testing.T) {
+		r := New()
+		var order []int
+		var captured []func()
+		r.Set("installHook", func() {
+			r.SetPromiseJobEnqueuer(func(job func()) {
+				captured = append(captured, job)
+			})
+		})
+		r.Set("push", func(v int) { order = append(order, v) })
+		_, err := r.RunString(`
+			Promise.resolve().then(() => push(1));
+			Promise.resolve().then(() => push(2));
+			Promise.resolve().then(() => push(3));
+			installHook();
+		`)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(captured) != 3 {
+			t.Fatalf("expected 3 forwarded jobs, got %d", len(captured))
+		}
+		drainJobs(t, r, &captured)
+		if len(order) != 3 || order[0] != 1 || order[1] != 2 || order[2] != 3 {
+			t.Fatalf("expected order=[1 2 3], got %v", order)
+		}
+	})
+
+	// Installing the hook mid-turn: jobs enqueued after the hook is set
+	// are delivered directly during the turn, before older jobs forwarded
+	// from the internal queue at turn exit. This violates global FIFO and
+	// is documented on PromiseJobEnqueuer.
+	t.Run("hook-installed-mid-turn-ordering", func(t *testing.T) {
+		r := New()
+		var order []int
+		var captured []func()
+		r.Set("push", func(v int) { order = append(order, v) })
+		r.Set("installHook", func() {
+			r.SetPromiseJobEnqueuer(func(job func()) {
+				captured = append(captured, job)
+			})
+		})
+		_, err := r.RunString(`
+			Promise.resolve().then(() => push(1));
+			Promise.resolve().then(() => push(2));
+			installHook();
+			Promise.resolve().then(() => push(3));
+			Promise.resolve().then(() => push(4));
+		`)
+		if err != nil {
+			t.Fatal(err)
+		}
+		// Jobs 1,2 were in the internal queue before the hook was set;
+		// jobs 3,4 were delivered directly. leave() forwards [1,2] after
+		// [3,4], so captured is [3,4,1,2].
+		if len(captured) != 4 {
+			t.Fatalf("expected 4 captured jobs, got %d", len(captured))
+		}
+		drainJobs(t, r, &captured)
+		if len(order) != 4 || order[0] != 3 || order[1] != 4 || order[2] != 1 || order[3] != 2 {
+			t.Fatalf("expected order=[3 4 1 2] (non-FIFO: direct jobs before forwarded), got %v", order)
+		}
+		if r.jobQueue != nil {
+			t.Fatalf("r.jobQueue should be nil after leave(), got len=%d", len(r.jobQueue))
+		}
+		if _, err := r.RunString(`1 + 1`); err != nil {
+			t.Fatalf("runtime not reusable: %v", err)
+		}
+	})
+
+	// RunPromiseJob forwards internally queued jobs to the hook on success.
+	t.Run("runpromisejob-forwards-to-hook", func(t *testing.T) {
+		r := New()
+		var secondRan bool
+		var captured []func()
+		r.SetPromiseJobEnqueuer(func(job func()) {
+			captured = append(captured, job)
+		})
+		r.Set("mark", func() { secondRan = true })
+		r.Set("clearHook", func() { r.SetPromiseJobEnqueuer(nil) })
+		r.Set("restoreHook", func() {
+			r.SetPromiseJobEnqueuer(func(job func()) {
+				captured = append(captured, job)
+			})
+		})
+		_, err := r.RunString(`Promise.resolve().then(function() { clearHook(); Promise.resolve().then(function() { mark() }); restoreHook(); })`)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(captured) != 1 {
+			t.Fatalf("expected 1 captured job, got %d", len(captured))
+		}
+		// Run the first job: clears hook, enqueues a second reaction
+		// to the internal queue, restores the hook. RunPromiseJob
+		// should forward the queued job to the hook.
+		if err := r.RunPromiseJob(captured[0]); err != nil {
+			t.Fatalf("RunPromiseJob: %v", err)
+		}
+		if len(captured) != 2 {
+			t.Fatalf("expected 2 captured jobs after RunPromiseJob, got %d", len(captured))
+		}
+		if err := r.RunPromiseJob(captured[1]); err != nil {
+			t.Fatalf("RunPromiseJob for forwarded job: %v", err)
+		}
+		if !secondRan {
+			t.Fatal("second reaction was not forwarded to hook")
+		}
+		if r.jobQueue != nil {
+			t.Fatalf("r.jobQueue should be nil, got len=%d", len(r.jobQueue))
+		}
+	})
+
+	t.Run("runpromisejob-hook-cleared-mid-batch-preserves-fifo", func(t *testing.T) {
+		r := New()
+		var order []int
+		var captured []func()
+
+		r.Set("push", func(v int) { order = append(order, v) })
+		r.Set("clearHook", func() { r.SetPromiseJobEnqueuer(nil) })
+		r.Set("restoreSyncHook", func() {
+			r.SetPromiseJobEnqueuer(func(job func()) {
+				if err := r.RunPromiseJob(job); err != nil {
+					t.Fatalf("RunPromiseJob from sync hook: %v", err)
+				}
+			})
+		})
+		r.SetPromiseJobEnqueuer(func(job func()) {
+			captured = append(captured, job)
+		})
+
+		_, err := r.RunString(`
+			Promise.resolve().then(function() {
+				clearHook();
+				Promise.resolve().then(function() {
+					push(1);
+					clearHook();
+					Promise.resolve().then(function() { push(3); });
+				});
+				Promise.resolve().then(function() { push(2); });
+				restoreSyncHook();
+			});
+		`)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(captured) != 1 {
+			t.Fatalf("expected 1 captured job, got %d", len(captured))
+		}
+
+		if err := r.RunPromiseJob(captured[0]); err != nil {
+			t.Fatalf("RunPromiseJob: %v", err)
+		}
+		if len(order) != 1 || order[0] != 1 {
+			t.Fatalf("expected only first forwarded job to have run immediately, got order=%v", order)
+		}
+		if _, err := r.RunString(`1 + 1`); err != nil {
+			t.Fatalf("RunString drain: %v", err)
+		}
+		if len(order) != 3 || order[0] != 1 || order[1] != 2 || order[2] != 3 {
+			t.Fatalf("expected FIFO order [1 2 3], got %v", order)
+		}
+	})
+
+	// A sync hook that clears itself during leave() forwarding: jobs
+	// enqueued after clearing must be drained internally, not forwarded
+	// to the removed hook.
+	t.Run("hook-cleared-during-leave-forwarding", func(t *testing.T) {
+		r := New()
+		var order []int
+		var hookCallCount int
+		r.Set("push", func(v int) { order = append(order, v) })
+		r.Set("installSyncHook", func() {
+			r.SetPromiseJobEnqueuer(func(job func()) {
+				hookCallCount++
+				r.RunPromiseJob(job)
+			})
+		})
+		r.Set("clearHook", func() { r.SetPromiseJobEnqueuer(nil) })
+		_, err := r.RunString(`
+			Promise.resolve().then(function() {
+				push(1);
+				clearHook();
+				Promise.resolve().then(function() { push(2); });
+			});
+			installSyncHook();
+		`)
+		if err != nil {
+			t.Fatal(err)
+		}
+		// Only A was forwarded to the sync hook; B was drained internally
+		// after the hook was cleared.
+		if hookCallCount != 1 {
+			t.Fatalf("expected hookCallCount=1 (only A forwarded, B drained internally), got %d", hookCallCount)
+		}
+		if len(order) != 2 || order[0] != 1 || order[1] != 2 {
+			t.Fatalf("expected order=[1 2], got %v", order)
+		}
+		if r.jobQueue != nil {
+			t.Fatalf("r.jobQueue should be nil, got len=%d", len(r.jobQueue))
+		}
+		if _, err := r.RunString(`1 + 1`); err != nil {
+			t.Fatalf("runtime not reusable: %v", err)
+		}
+	})
+
+	// Exited() must be called before capability.resolve/reject so the
+	// tracker does not span thenable assimilation. When the handler
+	// returns a thenable, resolve calls its 'then' method.
+	t.Run("tracker-exited-before-resolution", func(t *testing.T) {
+		r := New()
+		var tracker testAsyncContextTracker
+		tracker.logFunc = t.Log
+		tracker.ctx = &testAsyncCtx{group: "g", refCount: 0}
+		r.SetAsyncContextTracker(&tracker)
+
+		var thenCalledWhileResumed bool
+		r.SetPromiseJobEnqueuer(func(job func()) {
+			r.RunPromiseJob(job)
+		})
+
+		// The thenable's 'then' is called during assimilation inside
+		// capability.resolve, after the handler returns.
+		r.Set("makeThenable", func() Value {
+			thenFn := r.ToValue(func(call FunctionCall) Value {
+				if tracker.resumed {
+					thenCalledWhileResumed = true
+				}
+				return _undefined
+			})
+			obj := r.NewObject()
+			obj.Set("then", thenFn)
+			return obj
+		})
+
+		_, err := r.RunString(`Promise.resolve().then(function() { return makeThenable(); })`)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if thenCalledWhileResumed {
+			t.Fatal("tracker was still resumed when 'then' was called during thenable assimilation; Exited() was not called before capability.resolve()")
+		}
+		if _, err := r.RunString(`1 + 1`); err != nil {
+			t.Fatalf("runtime not reusable: %v", err)
+		}
+	})
+
+	// Sync hook + tracker + chained pending reactions: resolving a
+	// promise triggers a downstream reaction reentrantly via the sync
+	// hook. Exited() must have been called before resolve so the
+	// nested Resumed() does not panic.
+	t.Run("sync-hook-tracker-chained-reactions", func(t *testing.T) {
+		r := New()
+		var tracker testAsyncContextTracker
+		tracker.logFunc = t.Log
+		tracker.ctx = &testAsyncCtx{group: "g", refCount: 0}
+		r.SetAsyncContextTracker(&tracker)
+
+		var chainCompleted bool
+		r.Set("mark", func() { chainCompleted = true })
+		r.SetPromiseJobEnqueuer(func(job func()) {
+			r.RunPromiseJob(job)
+		})
+
+		// Chain a reaction on the derived promise, then resolve p.
+		// The sync hook runs J1; J1's resolve triggers J2 reentrantly.
+		_, err := r.RunString(`
+			var resolveP;
+			var p = new Promise(function(resolve) { resolveP = resolve; });
+			var derived = p.then(function() {});
+			derived.then(function() { mark(); });
+			resolveP();
+		`)
+		if err != nil {
+			t.Fatalf("RunString: %v", err)
+		}
+		if !chainCompleted {
+			t.Fatal("promise chain did not complete; tracker.Resumed() may have panicked with 'Nested Resumed() calls'")
+		}
+		if _, err := r.RunString(`1 + 1`); err != nil {
+			t.Fatalf("runtime not reusable: %v", err)
+		}
+	})
+
+	// Two jobs in the same initial batch: the first clears the hook,
+	// the second must not be forwarded to the removed hook.
+	t.Run("same-batch-stale-hook", func(t *testing.T) {
+		r := New()
+		var order []int
+		var hookCallCount int
+		r.Set("push", func(v int) { order = append(order, v) })
+		r.Set("installSyncHook", func() {
+			r.SetPromiseJobEnqueuer(func(job func()) {
+				hookCallCount++
+				r.RunPromiseJob(job)
+			})
+		})
+		r.Set("clearHook", func() { r.SetPromiseJobEnqueuer(nil) })
+		_, err := r.RunString(`
+			Promise.resolve().then(function() { clearHook(); push(1); });
+			Promise.resolve().then(function() { push(2); });
+			installSyncHook();
+		`)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if hookCallCount != 1 {
+			t.Fatalf("expected hookCallCount=1, got %d", hookCallCount)
+		}
+		if len(order) != 2 || order[0] != 1 || order[1] != 2 {
+			t.Fatalf("expected order=[1 2], got %v", order)
+		}
+		if r.jobQueue != nil {
+			t.Fatalf("r.jobQueue should be nil, got len=%d", len(r.jobQueue))
+		}
+		if _, err := r.RunString(`1 + 1`); err != nil {
+			t.Fatalf("runtime not reusable: %v", err)
+		}
+	})
+
+	// leaveAbrupt with a sync hook: the interrupt flag must stay active
+	// for all forwarded jobs. Nested leaveAbrupt() calls (from
+	// RunPromiseJob's error path) must not clear the interrupt.
+	t.Run("leaveabrupt-interrupt-not-cleared", func(t *testing.T) {
+		r := New()
+		var order []int
+		var hookCallCount int
+		r.Set("push", func(v int) { order = append(order, v) })
+		r.Set("installSyncHookAndInterrupt", func() {
+			r.SetPromiseJobEnqueuer(func(job func()) {
+				hookCallCount++
+				_ = r.RunPromiseJob(job)
+			})
+			r.Interrupt("test-abrupt")
+		})
+		// Both jobs are in r.jobQueue before the hook is set. The hook
+		// is then installed and the interrupt triggered.
+		_, err := r.RunString(`
+			Promise.resolve().then(function() { push(1); });
+			Promise.resolve().then(function() { push(2); });
+			installSyncHookAndInterrupt();
+		`)
+		if err == nil {
+			t.Fatal("expected InterruptedError from RunString, got nil")
+		}
+		if hookCallCount != 2 {
+			t.Fatalf("expected hookCallCount=2, got %d", hookCallCount)
+		}
+		// No jobs should have run, both interrupted.
+		if len(order) != 0 {
+			t.Fatalf("expected order=[], got %v", order)
+		}
+		if _, err := r.RunString(`1 + 1`); err != nil {
+			t.Fatalf("runtime not reusable: %v", err)
+		}
+	})
+
+	// Standalone RunPromiseJob with a native handler calling RunString:
+	// the sentinel context ensures the nested RunProgram is treated as
+	// recursive so leave() does not drain jobs while the outer tracker
+	// is still resumed.
+	t.Run("standalone-runpromisejob-native-reentry", func(t *testing.T) {
+		r := New()
+		var tracker testAsyncContextTracker
+		tracker.logFunc = t.Log
+		tracker.ctx = &testAsyncCtx{group: "g", refCount: 0}
+		r.SetAsyncContextTracker(&tracker)
+
+		var captured []func()
+		r.SetPromiseJobEnqueuer(func(job func()) {
+			captured = append(captured, job)
+		})
+
+		// nativeHandler clears the hook and calls RunString which
+		// creates a new promise reaction.
+		r.Set("nativeHandler", func() {
+			r.SetPromiseJobEnqueuer(nil)
+			_, _ = r.RunString(`Promise.resolve().then(function() {})`)
+		})
+
+		// Capture the reaction job.
+		_, err := r.RunString(`Promise.resolve().then(nativeHandler)`)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(captured) != 1 {
+			t.Fatalf("expected 1 captured job, got %d", len(captured))
+		}
+
+		// Execute the captured job standalone (callStack empty).
+		err = r.RunPromiseJob(captured[0])
+		if err != nil {
+			t.Fatalf("RunPromiseJob: %v", err)
+		}
+
+		// Drain jobs that accumulated in r.jobQueue during the nested
+		// RunString (hook was cleared).
+		if _, err := r.RunString(`1 + 1`); err != nil {
+			t.Fatalf("runtime not reusable: %v", err)
+		}
+	})
+
+	// The tracker used at execution time must be the one captured at
+	// scheduling time, not the current runtime tracker. Tracker B is
+	// poisoned (resumed=true) so a reaction that wrongly uses B panics.
+	t.Run("tracker-identity-captured", func(t *testing.T) {
+		r := New()
+
+		// Tracker A, active when the reaction is created.
+		var trackerA testAsyncContextTracker
+		trackerA.logFunc = t.Log
+		trackerA.ctx = &testAsyncCtx{group: "A", refCount: 0}
+		r.SetAsyncContextTracker(&trackerA)
+
+		var captured []func()
+		r.SetPromiseJobEnqueuer(func(job func()) {
+			captured = append(captured, job)
+		})
+
+		_, err := r.RunString(`Promise.resolve().then(function() {})`)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(captured) != 1 {
+			t.Fatalf("expected 1 captured job, got %d", len(captured))
+		}
+
+		// Replace with tracker B, poisoned so Resumed panics if used.
+		var trackerB testAsyncContextTracker
+		trackerB.logFunc = t.Log
+		trackerB.ctx = &testAsyncCtx{group: "B", refCount: 0}
+		trackerB.resumed = true
+		r.SetAsyncContextTracker(&trackerB)
+
+		// Should use trackerA (captured at scheduling time), not trackerB.
+		err = r.RunPromiseJob(captured[0])
+		if err != nil {
+			t.Fatalf("RunPromiseJob: %v", err)
+		}
+
+		if _, err := r.RunString(`1 + 1`); err != nil {
+			t.Fatalf("runtime not reusable: %v", err)
+		}
+	})
+
+	// Hook replacement during same-batch forwarding: job A replaces
+	// the hook, job B must go to the new hook, not the stale one.
+	t.Run("hook-replacement-during-forwarding", func(t *testing.T) {
+		r := New()
+		var order []int
+		var hookACount, hookBCount int
+		r.Set("push", func(v int) { order = append(order, v) })
+		r.Set("installHookA", func() {
+			r.SetPromiseJobEnqueuer(func(job func()) {
+				hookACount++
+				r.RunPromiseJob(job)
+			})
+		})
+		r.Set("replaceWithHookB", func() {
+			r.SetPromiseJobEnqueuer(func(job func()) {
+				hookBCount++
+				r.RunPromiseJob(job)
+			})
+		})
+		_, err := r.RunString(`
+			Promise.resolve().then(function() { replaceWithHookB(); push(1); });
+			Promise.resolve().then(function() { push(2); });
+			installHookA();
+		`)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if hookACount != 1 {
+			t.Fatalf("expected hookACount=1, got %d", hookACount)
+		}
+		if hookBCount != 1 {
+			t.Fatalf("expected hookBCount=1, got %d", hookBCount)
+		}
+		if len(order) != 2 || order[0] != 1 || order[1] != 2 {
+			t.Fatalf("expected order=[1 2], got %v", order)
+		}
+		if _, err := r.RunString(`1 + 1`); err != nil {
+			t.Fatalf("runtime not reusable: %v", err)
+		}
+	})
+
+	// leaveAbrupt must clear vm.prg, vm.sb, vm.stack, and r.jobQueue.
+	t.Run("leaveabrupt-clears-prg-sb", func(t *testing.T) {
+		r := New()
+		r.Set("boom", func() { r.Interrupt("test-abrupt") })
+		_, err := r.RunString(`
+			var x = 1 + 2;
+			boom();
+		`)
+		if err == nil {
+			t.Fatal("expected InterruptedError, got nil")
+		}
+		if r.vm.prg != nil {
+			t.Fatalf("vm.prg should be nil after leaveAbrupt, got %v", r.vm.prg)
+		}
+		if r.vm.sb != -1 {
+			t.Fatalf("vm.sb should be -1 after leaveAbrupt, got %d", r.vm.sb)
+		}
+		if r.vm.stack != nil {
+			t.Fatal("vm.stack should be nil after leaveAbrupt")
+		}
+		if r.jobQueue != nil {
+			t.Fatalf("r.jobQueue should be nil after leaveAbrupt, got len=%d", len(r.jobQueue))
+		}
+		if _, err := r.RunString(`1 + 1`); err != nil {
+			t.Fatalf("runtime not reusable: %v", err)
+		}
+	})
+
+	// If the hook panics during RunPromiseJob's forwarding loop, the
+	// sentinel context must still be popped from r.vm.callStack.
+	t.Run("hook-panic-forwarding-no-sentinel-leak", func(t *testing.T) {
+		r := New()
+		var captured []func()
+		r.SetPromiseJobEnqueuer(func(job func()) {
+			captured = append(captured, job)
+		})
+		sentinel := errors.New("hook panic during forwarding")
+		r.Set("setup", func() {
+			// Clear the hook so the reaction job goes to r.jobQueue.
+			r.SetPromiseJobEnqueuer(nil)
+			_, _ = r.RunString(`Promise.resolve().then(function() {})`)
+			// Install a panicking hook for the forwarding loop to call.
+			r.SetPromiseJobEnqueuer(func(job func()) { panic(sentinel) })
+		})
+		_, err := r.RunString(`Promise.resolve().then(setup)`)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(captured) != 1 {
+			t.Fatalf("expected 1 captured job, got %d", len(captured))
+		}
+
+		// Run the captured job: setup() enqueues a reaction to
+		// r.jobQueue and installs the panicking hook. The forwarding
+		// loop calls the hook, causing a panic.
+		func() {
+			defer func() {
+				if x := recover(); x == nil {
+					t.Fatal("expected RunPromiseJob to re-panic from hook panic during forwarding")
+				} else if x != sentinel {
+					t.Fatalf("expected re-panic with sentinel, got %v (%T)", x, x)
+				}
+			}()
+			_ = r.RunPromiseJob(captured[0])
+		}()
+
+		// No sentinel leak.
+		if len(r.vm.callStack) != 0 {
+			t.Fatalf("callStack should be empty, got len=%d", len(r.vm.callStack))
+		}
+		// Runtime must remain reusable.
+		if _, err := r.RunString(`1 + 1`); err != nil {
+			t.Fatalf("runtime not reusable after hook panic: %v", err)
+		}
+	})
+
+	// If Exited() panics, it must not be called a second time by the
+	// defer safety net.
+	t.Run("tracker-exited-panic-no-double-call", func(t *testing.T) {
+		r := New()
+		var tracker countingAsyncContextTracker
+		exitedOnce := false
+		tracker.exitFunc = func() {
+			if !exitedOnce {
+				exitedOnce = true
+				panic("Exited() panic on first call")
+			}
+			panic("Exited() called twice")
+		}
+		r.SetAsyncContextTracker(&tracker)
+		r.SetPromiseJobEnqueuer(func(job func()) {
+			r.RunPromiseJob(job)
+		})
+
+		defer func() {
+			if x := recover(); x == nil {
+				t.Fatal("expected Exited() panic to propagate")
+			}
+			if tracker.exited != 1 {
+				t.Fatalf("Exited() should be called once, got %d", tracker.exited)
+			}
+		}()
+
+		_, err := r.RunString(`Promise.resolve().then(function() {})`)
+		if err != nil {
+			t.Logf("RunString returned err: %v", err)
+		}
+	})
+
+	// Nil-handler propagation reactions must call Resumed and Exited.
+	t.Run("nil-handler-tracker-invariant", func(t *testing.T) {
+		r := New()
+		var tracker countingAsyncContextTracker
+		r.SetAsyncContextTracker(&tracker)
+
+		// Promise.resolve(1).then() with no fulfill handler.
+		_, err := r.RunString(`Promise.resolve(1).then()`)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if tracker.grabbed != 1 {
+			t.Fatalf("expected Grab=1, got %d", tracker.grabbed)
+		}
+		if tracker.resumed != 1 {
+			t.Fatalf("expected Resumed=1, got %d", tracker.resumed)
+		}
+		if tracker.exited != 1 {
+			t.Fatalf("expected Exited=1, got %d", tracker.exited)
+		}
+		if _, err := r.RunString(`1 + 1`); err != nil {
+			t.Fatalf("runtime not reusable: %v", err)
+		}
+	})
+
+	// A sync hook with a tracker: a reaction enqueued during the handler
+	// must be buffered until Exited() returns, not delivered to the hook
+	// while the tracker is still resumed.
+	t.Run("sync-hook-tracker-handler-enqueued-reaction", func(t *testing.T) {
+		r := New()
+		var tracker testAsyncContextTracker
+		tracker.logFunc = t.Log
+		tracker.ctx = &testAsyncCtx{group: "g", refCount: 0}
+		r.SetAsyncContextTracker(&tracker)
+
+		var innerRan bool
+		r.Set("markInner", func() { innerRan = true })
+		r.SetPromiseJobEnqueuer(func(job func()) {
+			if err := r.RunPromiseJob(job); err != nil {
+				t.Fatalf("RunPromiseJob: %v", err)
+			}
+		})
+
+		_, err := r.RunString(`
+			Promise.resolve().then(function () {
+				Promise.resolve().then(function () { markInner(); });
+			});
+		`)
+		if err != nil {
+			t.Fatalf("RunString: %v", err)
+		}
+		if !innerRan {
+			t.Fatal("inner reaction did not run")
+		}
+		if _, err := r.RunString(`1 + 1`); err != nil {
+			t.Fatalf("runtime not reusable: %v", err)
+		}
+	})
+
+	t.Run("tracker-resumed-enqueue-buffers-until-resumed-returns", func(t *testing.T) {
+		r := New()
+		tracker := &resumedEnqueueTracker{r: r}
+		r.SetAsyncContextTracker(tracker)
+
+		var resumedEnqueuedJobRan bool
+		r.Set("markResumedEnqueued", func() {
+			resumedEnqueuedJobRan = true
+		})
+		r.SetPromiseJobEnqueuer(func(job func()) {
+			if err := r.RunPromiseJob(job); err != nil {
+				t.Fatalf("RunPromiseJob: %v", err)
+			}
+		})
+
+		defer func() {
+			if x := recover(); x != nil {
+				t.Fatalf("expected Resumed() to enqueue promise work without nested Resumed; got panic: %v", x)
+			}
+		}()
+
+		_, err := r.RunString(`Promise.resolve().then(function () {})`)
+		if err != nil {
+			t.Fatalf("RunString: %v", err)
+		}
+		if !tracker.enqueued {
+			t.Fatal("tracker.Resumed() did not enqueue the nested promise job")
+		}
+		if !resumedEnqueuedJobRan {
+			t.Fatal("promise job enqueued by Resumed() did not run after Resumed() returned")
+		}
+		if _, err := r.RunString(`1 + 1`); err != nil {
+			t.Fatalf("runtime not reusable: %v", err)
+		}
+	})
+
+	t.Run("tracker-resumed-enqueued-job-precedes-downstream-reaction", func(t *testing.T) {
+		r := New()
+		tracker := &resumedEnqueueTracker{r: r}
+		r.SetAsyncContextTracker(tracker)
+
+		var order []int
+		r.Set("markResumedEnqueued", func() { order = append(order, 1) })
+		r.Set("push", func(v int) { order = append(order, v) })
+		r.SetPromiseJobEnqueuer(func(job func()) {
+			if err := r.RunPromiseJob(job); err != nil {
+				t.Fatalf("RunPromiseJob: %v", err)
+			}
+		})
+
+		_, err := r.RunString(`Promise.resolve().then(function () {}).then(function () { push(2); })`)
+		if err != nil {
+			t.Fatalf("RunString: %v", err)
+		}
+		if len(order) != 2 || order[0] != 1 || order[1] != 2 {
+			t.Fatalf("expected tracker-enqueued job to precede downstream reaction [1 2], got %v", order)
+		}
+	})
+
+	t.Run("tracker-exited-enqueue-buffers-until-exited-returns", func(t *testing.T) {
+		r := New()
+		tracker := &exitedEnqueueTracker{r: r}
+		r.SetAsyncContextTracker(tracker)
+
+		var exitedEnqueuedJobRan bool
+		r.Set("markExitedEnqueued", func() {
+			exitedEnqueuedJobRan = true
+		})
+		r.SetPromiseJobEnqueuer(func(job func()) {
+			if err := r.RunPromiseJob(job); err != nil {
+				t.Fatalf("RunPromiseJob: %v", err)
+			}
+		})
+
+		defer func() {
+			if x := recover(); x != nil {
+				t.Fatalf("expected Exited() to enqueue promise work without nested Resumed; got panic: %v", x)
+			}
+		}()
+
+		_, err := r.RunString(`Promise.resolve().then(function () {})`)
+		if err != nil {
+			t.Fatalf("RunString: %v", err)
+		}
+		if !tracker.enqueued {
+			t.Fatal("tracker.Exited() did not enqueue the nested promise job")
+		}
+		if !exitedEnqueuedJobRan {
+			t.Fatal("promise job enqueued by Exited() did not run after Exited() returned")
+		}
+		if _, err := r.RunString(`1 + 1`); err != nil {
+			t.Fatalf("runtime not reusable: %v", err)
+		}
+	})
+
+	t.Run("tracker-exited-enqueued-job-precedes-downstream-reaction", func(t *testing.T) {
+		r := New()
+		tracker := &exitedEnqueueTracker{r: r}
+		r.SetAsyncContextTracker(tracker)
+
+		var order []int
+		r.Set("markExitedEnqueued", func() { order = append(order, 1) })
+		r.Set("push", func(v int) { order = append(order, v) })
+		r.SetPromiseJobEnqueuer(func(job func()) {
+			if err := r.RunPromiseJob(job); err != nil {
+				t.Fatalf("RunPromiseJob: %v", err)
+			}
+		})
+
+		_, err := r.RunString(`Promise.resolve().then(function () {}).then(function () { push(2); })`)
+		if err != nil {
+			t.Fatalf("RunString: %v", err)
+		}
+		if len(order) != 2 || order[0] != 1 || order[1] != 2 {
+			t.Fatalf("expected tracker-enqueued job to precede downstream reaction [1 2], got %v", order)
 		}
 	})
 }
@@ -414,7 +1993,7 @@ func TestGeneratorReturnIterCleanupThrow1(t *testing.T) {
 			yield 2;
 		}
 	}
-	
+
 	const gen = g();
 	assert.sameValue(gen.next().value, 1);
 	assert.sameValue(gen.next().value, 2);
@@ -569,7 +2148,7 @@ func TestGeneratorReturn(t *testing.T) {
 		yield 'cleanup';  // Should suspend here
 	  }
 	}
-	
+
 	const gen = withCleanup();
 	const r1 = gen.next();           // {value: 'working', done: false}
 	assert.sameValue(r1.value, 'working');
@@ -600,14 +2179,14 @@ func TestGeneratorReturn1(t *testing.T) {
 		yield "outer-cleanup";
 	  }
 	}
-	
+
 	var gen = nestedCleanup();
 	var result;
-	
+
 	result = gen.next();
 	assert.sameValue(result.value, "work", "r1.value");
 	assert.sameValue(result.done, false, "r1.done");
-	
+
 	result = gen.return("cancelled");
 	assert.sameValue(
 	  result.value,
@@ -615,7 +2194,7 @@ func TestGeneratorReturn1(t *testing.T) {
 	  "r2.value (inner finally yield)",
 	);
 	assert.sameValue(result.done, false, "r2.done (suspended at inner finally)");
-	
+
 	result = gen.next();
 	assert.sameValue(
 	  result.value,
@@ -623,7 +2202,7 @@ func TestGeneratorReturn1(t *testing.T) {
 	  "r3.value (outer finally yield)",
 	);
 	assert.sameValue(result.done, false, "r3.done (suspended at outer finally)");
-	
+
 	result = gen.next();
 	assert.sameValue(result.value, "cancelled", "r4.value (return value)");
 	assert.sameValue(result.done, true, "r4.done (completed)");
@@ -640,12 +2219,12 @@ func TestGeneratorReturn2(t *testing.T) {
 		return "cleanup-override";
 	  }
 	}
-	
+
 	var gen = genWithOverride();
 	gen.next();
-	
+
 	var result = gen.return("cancelled");
-	
+
 	assert.sameValue(
 	  result.value,
 	  "cleanup-override",
@@ -666,24 +2245,24 @@ func TestGeneratorReturn3(t *testing.T) {
 		throw new Error("cleanup-failed-after-yield");
 	  }
 	}
-	
+
 	var gen = genWithSuspendingThrowingCleanup();
 	var result;
-	
+
 	result = gen.next();
 	assert.sameValue(result.value, "work", "r1.value");
-	
+
 	result = gen.return("cancelled");
 	assert.sameValue(result.value, "cleanup", "r2.value (yield in finally)");
 	assert.sameValue(result.done, false, "r2.done (suspended at yield)");
-	
+
 	var caught;
 	try {
 	  gen.next();
 	} catch (e) {
 	  caught = e.message;
 	}
-	
+
 	assert.sameValue(
 	  caught,
 	  "cleanup-failed-after-yield",
@@ -702,17 +2281,17 @@ func TestGeneratorReturn4(t *testing.T) {
 		throw new Error("cleanup-failed");
 	  }
 	}
-	
+
 	var gen = genWithThrowingCleanup();
 	gen.next();
-	
+
 	var caught;
 	try {
 	  gen.return("cancelled");
 	} catch (e) {
 	  caught = e.message;
 	}
-	
+
 	assert.sameValue(
 	  caught,
 	  "cleanup-failed",
@@ -725,7 +2304,7 @@ func TestGeneratorReturn4(t *testing.T) {
 func TestGeneratorReturn5(t *testing.T) {
 	const SCRIPT = `
 	var cleanupInput;
-	
+
 	function* cleanupNeedsAck() {
 	  try {
 		yield "work";
@@ -734,25 +2313,25 @@ func TestGeneratorReturn5(t *testing.T) {
 		yield "cleanup-2";
 	  }
 	}
-	
+
 	var gen = cleanupNeedsAck();
 	var result;
-	
+
 	result = gen.next();
 	assert.sameValue(result.value, "work", "r1.value");
-	
+
 	result = gen.return("cancelled");
 	assert.sameValue(result.value, "cleanup-1", "r2.value");
 	assert.sameValue(result.done, false, "r2.done");
-	
+
 	result = gen.next("ack");
 	assert.sameValue(result.value, "cleanup-2", "r3.value");
 	assert.sameValue(result.done, false, "r3.done");
-	
+
 	result = gen.next();
 	assert.sameValue(result.value, "cancelled", "r4.value");
 	assert.sameValue(result.done, true, "r4.done");
-	
+
 	assert.sameValue(
 	  cleanupInput,
 	  "ack",
@@ -765,7 +2344,7 @@ func TestGeneratorReturn5(t *testing.T) {
 func TestGeneratorReturn6(t *testing.T) {
 	const SCRIPT = `
 	var cleanupOrder = [];
-	
+
 	function* inner() {
 	  try {
 		yield "inner-work";
@@ -775,7 +2354,7 @@ func TestGeneratorReturn6(t *testing.T) {
 		cleanupOrder.push("inner");
 	  }
 	}
-	
+
 	function* outer() {
 	  try {
 		var result = yield* inner();
@@ -785,10 +2364,10 @@ func TestGeneratorReturn6(t *testing.T) {
 		cleanupOrder.push("outer");
 	  }
 	}
-	
+
 	var gen = outer();
 	var result;
-	
+
 	result = gen.next();
 	assert.sameValue(
 	  result.value,
@@ -796,7 +2375,7 @@ func TestGeneratorReturn6(t *testing.T) {
 	  "First yield from inner generator",
 	);
 	assert.sameValue(result.done, false, "First result done");
-	
+
 	result = gen.return("cancelled");
 	assert.sameValue(
 	  result.value,
@@ -804,7 +2383,7 @@ func TestGeneratorReturn6(t *testing.T) {
 	  "Should yield from inner finally",
 	);
 	assert.sameValue(result.done, false, "Should suspend at inner finally yield");
-	
+
 	result = gen.next();
 	assert.sameValue(
 	  result.value,
@@ -812,7 +2391,7 @@ func TestGeneratorReturn6(t *testing.T) {
 	  "Should yield from outer finally",
 	);
 	assert.sameValue(result.done, false, "Should suspend at outer finally yield");
-	
+
 	result = gen.next();
 	assert.sameValue(result.done, true, "Should be done after all finally blocks");
 	assert.sameValue(
@@ -830,7 +2409,7 @@ func TestGeneratorReturn7(t *testing.T) {
 	  yield "cleanup-1";
 	  yield "cleanup-2";
 	}
-	
+
 	function* withYieldStarCleanup() {
 	  try {
 		yield "work";
@@ -838,17 +2417,17 @@ func TestGeneratorReturn7(t *testing.T) {
 		yield* delegatedCleanup();
 	  }
 	}
-	
+
 	var gen = withYieldStarCleanup();
 	var result;
-	
+
 	result = gen.next();
 	assert.sameValue(result.value, "work", "r1.value");
-	
+
 	result = gen.return("cancelled");
 	assert.sameValue(result.value, "cleanup-1", "r2.value (first delegated yield)");
 	assert.sameValue(result.done, false, "r2.done");
-	
+
 	result = gen.next();
 	assert.sameValue(
 	  result.value,
@@ -856,7 +2435,7 @@ func TestGeneratorReturn7(t *testing.T) {
 	  "r3.value (second delegated yield)",
 	);
 	assert.sameValue(result.done, false, "r3.done");
-	
+
 	result = gen.next();
 	assert.sameValue(result.value, "cancelled", "r4.value (return value)");
 	assert.sameValue(result.done, true, "r4.done");
@@ -868,7 +2447,7 @@ func TestGeneratorReturn8(t *testing.T) {
 	const SCRIPT = `
 	var inFinally = 0;
 	var afterYield = 0;
-	
+
 	function* g() {
 	  try {
 		yield "in-try";
@@ -878,15 +2457,15 @@ func TestGeneratorReturn8(t *testing.T) {
 		afterYield += 1;
 	  }
 	}
-	
+
 	var iter = g();
 	var result;
-	
+
 	result = iter.next();
 	assert.sameValue(result.value, "in-try", "First result value");
 	assert.sameValue(result.done, false, "First result done");
 	assert.sameValue(inFinally, 0, "finally not yet entered");
-	
+
 	result = iter.return(42);
 	assert.sameValue(
 	  result.value,
@@ -896,7 +2475,7 @@ func TestGeneratorReturn8(t *testing.T) {
 	assert.sameValue(result.done, false, "Second result done (suspended at yield)");
 	assert.sameValue(inFinally, 1, "finally block entered");
 	assert.sameValue(afterYield, 0, "code after yield not yet executed");
-	
+
 	result = iter.next();
 	assert.sameValue(result.value, 42, "Third result value (return value)");
 	assert.sameValue(result.done, true, "Third result done (completed)");

--- a/runtime.go
+++ b/runtime.go
@@ -2931,6 +2931,11 @@ func (r *Runtime) getHash() *maphash.Hash {
 
 // called when the top level function returns normally (i.e. control is passed outside the Runtime).
 func (r *Runtime) leave() {
+	defer func() {
+		r.jobQueue = nil
+		r.promiseJobQueuePriority = false
+		r.vm.stack = nil
+	}()
 	// Re-read the hook per job so mid-batch clearing or replacement
 	// takes effect immediately.
 	for len(r.jobQueue) > 0 {
@@ -2944,9 +2949,6 @@ func (r *Runtime) leave() {
 			}
 		}
 	}
-	r.jobQueue = nil
-	r.promiseJobQueuePriority = false
-	r.vm.stack = nil
 }
 
 // called when the top level function returns (i.e. control is passed outside the Runtime) but it was due to an interrupt
@@ -2962,7 +2964,16 @@ func (r *Runtime) leaveAbrupt() {
 		return
 	}
 	r.leavingAbrupt = true
-	defer func() { r.leavingAbrupt = false }()
+	defer func() {
+		r.leavingAbrupt = false
+		// in a defer so cleanup still runs if hook(job) panics
+		r.jobQueue = nil
+		r.promiseJobQueuePriority = false
+		r.vm.stack = nil
+		r.vm.prg = nil
+		r.vm.sb = -1
+		r.ClearInterrupt()
+	}()
 
 	for len(r.jobQueue) > 0 {
 		if r.promiseJobEnqueuer == nil {
@@ -2975,15 +2986,18 @@ func (r *Runtime) leaveAbrupt() {
 			if hook == nil {
 				break
 			}
-			hook(job)
+			// recover so a panicking hook does not propagate out of
+			// leaveAbrupt; the caller's defer has already set the
+			// InterruptedError, so drop the panic and keep forwarding
+			// the remaining jobs.
+			func() {
+				defer func() {
+					_ = recover()
+				}()
+				hook(job)
+			}()
 		}
 	}
-	r.jobQueue = nil
-	r.promiseJobQueuePriority = false
-	r.vm.stack = nil
-	r.vm.prg = nil
-	r.vm.sb = -1
-	r.ClearInterrupt()
 }
 
 func nilSafe(v Value) Value {

--- a/runtime.go
+++ b/runtime.go
@@ -201,6 +201,16 @@ type Runtime struct {
 
 	promiseRejectionTracker PromiseRejectionTracker
 	asyncContextTracker     AsyncContextTracker
+	promiseJobEnqueuer      PromiseJobEnqueuer
+	leavingAbrupt           bool
+	// asyncTrackerActive is true while a reaction job's tracker is between
+	// Resumed and Exited. enqueuePromiseJob buffers jobs instead of delivering
+	// them to a synchronous hook during this window.
+	asyncTrackerActive bool
+	// promiseJobQueuePriority is true when r.jobQueue contains jobs buffered
+	// during a tracker scope. Later jobs are appended to the queue to preserve
+	// FIFO with the buffered jobs.
+	promiseJobQueuePriority bool
 
 	// Stack for tracking objects currently being converted to string
 	// to detect and handle circular references
@@ -1510,6 +1520,10 @@ func (r *Runtime) CaptureCallStack(depth int, stack []StackFrame) []StackFrame {
 // Interrupt a running JavaScript. The corresponding Go call will return an *InterruptedError containing v.
 // If the interrupt propagates until the stack is empty the currently queued promise resolve/reject jobs will be cleared
 // without being executed. This is the same time they would be executed otherwise.
+// If a PromiseJobEnqueuer is set, the queued jobs are forwarded to the hook instead of being cleared.
+// Note that during the abrupt-exit path the interrupt flag is still active when the hook is called, so a
+// synchronous hook that calls RunPromiseJob will see the jobs fail immediately. Capture jobs and drain
+// them after the runtime has recovered.
 // Note, it only works while in JavaScript code, it does not interrupt native Go functions (which includes all built-ins).
 // If the runtime is currently not running, it will be immediately interrupted on the next Run*() call.
 // To avoid that use ClearInterrupt()
@@ -2527,6 +2541,88 @@ func (r *Runtime) runWrapped(f func()) (err error) {
 	return
 }
 
+// RunPromiseJob runs a promise job captured through a PromiseJobEnqueuer hook.
+// Uncatchable exceptions (InterruptedError, StackOverflowError) are recovered
+// and returned; other panics are re-thrown. Not goroutine-safe.
+//
+// The job must be run on the same Runtime that produced it.
+//
+// On success, if the hook is set, any jobs the job enqueued internally are
+// forwarded to the hook. If the hook is nil, they remain in r.jobQueue and run
+// on the next Run*() call. On an uncatchable error, leaveAbrupt() forwards
+// stranded jobs, clears the queue, and resets the interrupt flag.
+//
+// When called reentrantly (from within a running script) the outer operand
+// stack is preserved and leaveAbrupt() is not called. An InterruptedError
+// leaves the interrupt flag set for the outer script; a StackOverflowError is
+// cleared by handleThrow and the outer script can continue.
+func (r *Runtime) RunPromiseJob(job func()) (err error) {
+	recursive := len(r.vm.callStack) > 0
+	if !recursive {
+		// Sentinel so nested RunProgram calls (e.g. a native handler
+		// calling r.RunString) are treated as recursive and do not
+		// drain the job queue via leave().
+		r.vm.callStack = append(r.vm.callStack, context{})
+	}
+	// Pop the sentinel before recover so a panicking hook does not
+	// leave it behind and poison future RunProgram calls.
+	defer func() {
+		if !recursive {
+			r.vm.callStack = r.vm.callStack[:len(r.vm.callStack)-1]
+		}
+		if x := recover(); x != nil {
+			if ex := asUncatchableException(x); ex != nil {
+				err = ex
+				if recursive {
+					r.vm.clearStack()
+				} else {
+					r.leaveAbrupt()
+				}
+			} else {
+				if recursive {
+					r.vm.clearStack()
+				}
+				panic(x)
+			}
+			return
+		}
+		if recursive {
+			r.vm.clearStack()
+		}
+	}()
+	r.vm.checkInterrupt()
+	job()
+	if !recursive {
+		r.vm.prg = nil
+		r.vm.sb = -1
+		r.vm.stack = nil
+	forward:
+		for len(r.jobQueue) > 0 {
+			jobs := r.jobQueue
+			r.jobQueue = nil
+			for i, job := range jobs {
+				// Re-read the hook per job so mid-batch clearing
+				// or replacement takes effect immediately.
+				hook := r.promiseJobEnqueuer
+				if hook == nil {
+					// Remaining jobs are older than anything
+					// the just-run job appended, so keep them
+					// ahead for the next Run*() call.
+					remaining := make([]func(), len(jobs[i:]))
+					copy(remaining, jobs[i:])
+					r.jobQueue = append(remaining, r.jobQueue...)
+					break forward
+				}
+				hook(job)
+			}
+		}
+		if len(r.jobQueue) == 0 {
+			r.promiseJobQueuePriority = false
+		}
+	}
+	return
+}
+
 // IsUndefined returns true if the supplied Value is undefined. Note, it checks against the real undefined, not
 // against the global object's 'undefined' property.
 func IsUndefined(v Value) bool {
@@ -2835,20 +2931,58 @@ func (r *Runtime) getHash() *maphash.Hash {
 
 // called when the top level function returns normally (i.e. control is passed outside the Runtime).
 func (r *Runtime) leave() {
-	var jobs []func()
+	// Re-read the hook per job so mid-batch clearing or replacement
+	// takes effect immediately.
 	for len(r.jobQueue) > 0 {
-		jobs, r.jobQueue = r.jobQueue, jobs[:0]
+		jobs := r.jobQueue
+		r.jobQueue = nil
 		for _, job := range jobs {
-			job()
+			if hook := r.promiseJobEnqueuer; hook != nil {
+				hook(job)
+			} else {
+				job()
+			}
 		}
 	}
 	r.jobQueue = nil
+	r.promiseJobQueuePriority = false
 	r.vm.stack = nil
 }
 
 // called when the top level function returns (i.e. control is passed outside the Runtime) but it was due to an interrupt
 func (r *Runtime) leaveAbrupt() {
+	// Nested calls (from RunPromiseJob's error path inside a hook)
+	// must not clear the interrupt; only the outermost call owns
+	// ClearInterrupt().
+	if r.leavingAbrupt {
+		r.jobQueue = nil
+		r.vm.stack = nil
+		r.vm.prg = nil
+		r.vm.sb = -1
+		return
+	}
+	r.leavingAbrupt = true
+	defer func() { r.leavingAbrupt = false }()
+
+	for len(r.jobQueue) > 0 {
+		if r.promiseJobEnqueuer == nil {
+			break
+		}
+		jobs := r.jobQueue
+		r.jobQueue = nil
+		for _, job := range jobs {
+			hook := r.promiseJobEnqueuer
+			if hook == nil {
+				break
+			}
+			hook(job)
+		}
+	}
 	r.jobQueue = nil
+	r.promiseJobQueuePriority = false
+	r.vm.stack = nil
+	r.vm.prg = nil
+	r.vm.sb = -1
 	r.ClearInterrupt()
 }
 

--- a/tc39_external_test.go
+++ b/tc39_external_test.go
@@ -1,0 +1,57 @@
+package goja
+
+import (
+	"os"
+	"testing"
+)
+
+// externalJobRunner is a host-owned FIFO queue for promise jobs captured
+// via PromiseJobEnqueuer and drained through RunPromiseJob.
+type externalJobRunner struct {
+	queue []func() // FIFO microtask queue
+	vm    *Runtime
+}
+
+// enqueue implements PromiseJobEnqueuer; appends to the queue tail.
+func (r *externalJobRunner) enqueue(job func()) {
+	r.queue = append(r.queue, job)
+}
+
+// drain runs each queued job via RunPromiseJob (which re-enqueues triggered
+// jobs). On an uncatchable error the queue is cleared.
+func (r *externalJobRunner) drain() error {
+	for len(r.queue) > 0 {
+		job := r.queue[0]
+		r.queue = r.queue[1:]
+		if err := r.vm.RunPromiseJob(job); err != nil {
+			r.queue = nil
+			return err
+		}
+	}
+	return nil
+}
+
+// TestTC39ExternalPromiseJobs runs test262 with a host-owned job queue:
+// jobs captured by PromiseJobEnqueuer are drained via RunPromiseJob after
+// each RunProgram.
+func TestTC39ExternalPromiseJobs(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	if _, err := os.Stat(tc39BASE); err != nil {
+		t.Skipf("If you want to run tc39 tests, download them from https://github.com/tc39/test262 and put into %s. See .tc39_test262_checkout.sh for the latest working commit id. (%v)", tc39BASE, err)
+	}
+
+	ctx := &tc39TestCtx{
+		base:                tc39BASE,
+		externalPromiseJobs: true,
+	}
+	ctx.init()
+
+	t.Run("tc39-external", func(t *testing.T) {
+		ctx.t = t
+		ctx.runAllTC39Tests()
+		ctx.flush()
+	})
+}

--- a/tc39_test.go
+++ b/tc39_test.go
@@ -440,6 +440,10 @@ type tc39TestCtx struct {
 	sabStub      *Program
 	//lint:ignore U1000 Only used with race
 	testQueue []tc39Test
+
+	// externalPromiseJobs enables a PromiseJobEnqueuer drained via RunPromiseJob
+	// after each RunProgram.
+	externalPromiseJobs bool
 }
 
 type TC39MetaNegative struct {
@@ -550,6 +554,16 @@ func (ctx *tc39TestCtx) runTC39Test(name, src string, meta *tc39Meta, t testing.
 		}
 	}()
 	vm := New()
+
+	// When set, install a PromiseJobEnqueuer and drain via RunPromiseJob after
+	// each RunProgram.
+	var drain func() error
+	if ctx.externalPromiseJobs {
+		runner := &externalJobRunner{vm: vm}
+		vm.SetPromiseJobEnqueuer(runner.enqueue)
+		drain = runner.drain
+	}
+
 	_262 := vm.NewObject()
 	_262.Set("detachArrayBuffer", ctx.detachArrayBuffer)
 	_262.Set("createRealm", ctx.throwIgnorableTestError)
@@ -564,10 +578,13 @@ func (ctx *tc39TestCtx) runTC39Test(name, src string, meta *tc39Meta, t testing.
 	vm.Set("$262", _262)
 	vm.Set("IgnorableTestError", ignorableTestError)
 	vm.RunProgram(ctx.sabStub)
+	if drain != nil {
+		drain()
+	}
 	var out []string
 	async := meta.hasFlag("async")
 	if async {
-		err := ctx.runFile(ctx.base, path.Join("harness", "doneprintHandle.js"), vm)
+		err := ctx.runFile(ctx.base, path.Join("harness", "doneprintHandle.js"), vm, drain)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -578,7 +595,7 @@ func (ctx *tc39TestCtx) runTC39Test(name, src string, meta *tc39Meta, t testing.
 		vm.Set("print", t.Log)
 	}
 
-	err, early := ctx.runTC39Script(name, src, meta.Includes, vm)
+	err, early := ctx.runTC39Script(name, src, meta.Includes, vm, drain)
 
 	if err != nil {
 		if meta.Negative.Type == "" {
@@ -750,30 +767,36 @@ func (ctx *tc39TestCtx) compile(base, name string) (*Program, error) {
 
 	return prg, nil
 }
-
-func (ctx *tc39TestCtx) runFile(base, name string, vm *Runtime) error {
+func (ctx *tc39TestCtx) runFile(base, name string, vm *Runtime, drain func() error) error {
 	prg, err := ctx.compile(base, name)
 	if err != nil {
 		return err
 	}
+
 	_, err = vm.RunProgram(prg)
-	return err
+	if err != nil {
+		return err
+	}
+	if drain != nil {
+		return drain()
+	}
+	return nil
 }
 
-func (ctx *tc39TestCtx) runTC39Script(name, src string, includes []string, vm *Runtime) (err error, early bool) {
+func (ctx *tc39TestCtx) runTC39Script(name, src string, includes []string, vm *Runtime, drain func() error) (err error, early bool) {
 	early = true
-	err = ctx.runFile(ctx.base, path.Join("harness", "assert.js"), vm)
+	err = ctx.runFile(ctx.base, path.Join("harness", "assert.js"), vm, drain)
 	if err != nil {
 		return
 	}
 
-	err = ctx.runFile(ctx.base, path.Join("harness", "sta.js"), vm)
+	err = ctx.runFile(ctx.base, path.Join("harness", "sta.js"), vm, drain)
 	if err != nil {
 		return
 	}
 
 	for _, include := range includes {
-		err = ctx.runFile(ctx.base, path.Join("harness", include), vm)
+		err = ctx.runFile(ctx.base, path.Join("harness", include), vm, drain)
 		if err != nil {
 			return
 		}
@@ -788,6 +811,12 @@ func (ctx *tc39TestCtx) runTC39Script(name, src string, includes []string, vm *R
 
 	early = false
 	_, err = vm.RunProgram(p)
+	if err != nil {
+		return
+	}
+	if drain != nil {
+		err = drain()
+	}
 
 	return
 }
@@ -817,6 +846,18 @@ func (ctx *tc39TestCtx) runTC39Tests(name string) {
 
 }
 
+// runAllTC39Tests runs the test262 directories shared by all run modes.
+func (ctx *tc39TestCtx) runAllTC39Tests() {
+	ctx.runTC39Tests("test/language")
+	ctx.runTC39Tests("test/built-ins")
+	ctx.runTC39Tests("test/annexB/built-ins/String/prototype/substr")
+	ctx.runTC39Tests("test/annexB/built-ins/String/prototype/trimLeft")
+	ctx.runTC39Tests("test/annexB/built-ins/String/prototype/trimRight")
+	ctx.runTC39Tests("test/annexB/built-ins/escape")
+	ctx.runTC39Tests("test/annexB/built-ins/unescape")
+	ctx.runTC39Tests("test/annexB/built-ins/RegExp")
+}
+
 func TestTC39(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
@@ -835,15 +876,7 @@ func TestTC39(t *testing.T) {
 	t.Run("tc39", func(t *testing.T) {
 		ctx.t = t
 		//ctx.runTC39File("test/language/types/number/8.5.1.js", t)
-		ctx.runTC39Tests("test/language")
-		ctx.runTC39Tests("test/built-ins")
-		ctx.runTC39Tests("test/annexB/built-ins/String/prototype/substr")
-		ctx.runTC39Tests("test/annexB/built-ins/String/prototype/trimLeft")
-		ctx.runTC39Tests("test/annexB/built-ins/String/prototype/trimRight")
-		ctx.runTC39Tests("test/annexB/built-ins/escape")
-		ctx.runTC39Tests("test/annexB/built-ins/unescape")
-		ctx.runTC39Tests("test/annexB/built-ins/RegExp")
-
+		ctx.runAllTC39Tests()
 		ctx.flush()
 	})
 

--- a/vm.go
+++ b/vm.go
@@ -636,13 +636,7 @@ func (vm *vm) run() {
 	}
 
 	if interrupted {
-		vm.interruptLock.Lock()
-		v := &InterruptedError{
-			iface: vm.interruptVal,
-		}
-		v.stack = vm.captureStack(nil, 0)
-		vm.interruptLock.Unlock()
-		panic(v)
+		vm.throwInterrupt()
 	}
 }
 
@@ -687,6 +681,22 @@ func (vm *vm) Interrupt(v interface{}) {
 	vm.interruptVal = v
 	atomic.StoreUint32(&vm.interrupted, 1)
 	vm.interruptLock.Unlock()
+}
+
+func (vm *vm) checkInterrupt() {
+	if atomic.LoadUint32(&vm.interrupted) != 0 {
+		vm.throwInterrupt()
+	}
+}
+
+func (vm *vm) throwInterrupt() {
+	vm.interruptLock.Lock()
+	v := &InterruptedError{
+		iface: vm.interruptVal,
+	}
+	v.stack = vm.captureStack(nil, 0)
+	vm.interruptLock.Unlock()
+	panic(v)
 }
 
 func (vm *vm) ClearInterrupt() {


### PR DESCRIPTION
## Why

This PR is to resolve a blocker I hit trying to use goja with my own event loop implementation.

Goja owns the promise job (microtask) queue and drains it internally at the end of every `RunString`/`RunProgram` call (and `AssertFunction`/`AssertConstructor` via `runWrapped`). There is no way for a host to intercept job scheduling. This makes it difficult to integrate goja with an external event loop or to implement custom microtask scheduling, because the runtime drains the queue before control returns to the host.

ECMA-262 defines `HostEnqueuePromiseJob` as the mechanism by which the host environment receives and schedules promise jobs. This PR exposes that hook so a host can capture jobs, defer them, and run them via `RunPromiseJob` when it chooses.

## New API

- `PromiseJobEnqueuer func(job func())`: host hook type, registered via `Runtime.SetPromiseJobEnqueuer`. Replaces the internal queue when set. `nil` (the default) restores the existing behavior.
- `Runtime.RunPromiseJob(job func()) error`: runs a job captured through the hook. Handles interrupt checking, stack cleanup, and reentrancy. Not goroutine-safe.

The hook runs on the runtime's goroutine. Jobs should be captured and run after the current turn returns. Synchronous invocation from within the hook is supported but does not preserve ECMA-262 turn ordering (documented on the type).

## Behavior

- **Default (nil enqueuer):** unchanged. Jobs queue internally and drain at turn exit via `leave()`.
- **With enqueuer:** jobs go to the hook instead of the internal queue.
- **Pending jobs at hook installation:** forwarded to the hook at turn exit (`leave()`). Jobs enqueued after the hook is set are delivered directly during the turn, so they reach the hook before the forwarded (older) jobs. Install the enqueuer before enqueuing any jobs if global FIFO ordering is required.
- **Interrupt path (`leaveAbrupt`):** stranded jobs are forwarded to the hook (with panic recovery) instead of being discarded. A `leavingAbrupt` guard prevents nested `ClearInterrupt` calls from `RunPromiseJob`'s error path. `leaveAbrupt` now also clears `vm.prg`, `vm.sb`, and `vm.stack` (previously left untouched on the abrupt path), and `leave()` uses a `defer` for cleanup so it runs even if a job panics.
- **`RunPromiseJob` reentrancy:** when called from Go (callStack empty), a sentinel context frame is pushed so that `RunProgram` calls made by the job (e.g. a native handler calling `r.RunString`) are treated as recursive and do not drain the job queue via `leave()`. When called from within a running script (recursive), no sentinel is needed; `clearStack()` restores the outer operand stack instead. The sentinel is popped before `recover()` so a panicking job cannot leak it. On success, internally queued jobs are forwarded to the hook; if the hook is nil they remain in `r.jobQueue` for the next `Run*()` call.

## AsyncContextTracker changes

The tracker was previously read from `r.asyncContextTracker` at job execution time. With external scheduling the tracker may change between scheduling and execution, so it is now captured at scheduling time and stored on the reaction.

`Exited()` is called before `capability.resolve`/`reject` rather than after, so the tracker brackets only the handler and not downstream resolution (thenable assimilation, reaction triggering). This prevents nested `Resumed()` calls when a synchronous hook runs downstream reactions reentrantly.

Two flags control job buffering during the tracker scope:
- `asyncTrackerActive`: set between `Resumed()` and `Exited()` (and re-activated during capability resolution when buffered jobs exist), so jobs are buffered instead of delivered to a synchronous hook.
- `promiseJobQueuePriority`: set when jobs are buffered during a tracker scope. Keeps all subsequent jobs buffered (even after `asyncTrackerActive` resets) to preserve FIFO with the already-buffered jobs. Cleared when the queue empties in `leave()` or `RunPromiseJob`.

Observable behavior changes for existing `AsyncContextTracker` users:
1. `Exited()` fires before the derived promise settles, not after.
2. Replacing or clearing the tracker affects only reactions scheduled after the change; pending reactions retain the tracker captured at scheduling time.
3. `Resumed`/`Exited` are called for nil-handler propagation reactions (e.g. `Promise.resolve(1).then()`).

## vm.go

`throwInterrupt()` extracted from `run()` (no behavior change). `checkInterrupt()` added so `RunPromiseJob` can check for a pending interrupt before running a captured job.
