### PR TITLE
upgrade staticcheck to 2026.2 for fix go 1.27 test fails.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Run staticcheck
         uses: dominikh/staticcheck-action@v1.4.1
         with:
-          version: "2026.1"
+          version: "2026.2"
           install-go: false
           cache-key: ${{ matrix.go-version }}
         if: ${{ matrix.go-version == '1.x' }}


### PR DESCRIPTION
upgrade staticcheck to 2026.2 for fix go 1.27 test fails.

- fixes #724 