### PR TITLE
Use monotonic counter for Object ID to avoid WeakMap address reuse issues

### DIFF
--- a/builtin_weakmap_test.go
+++ b/builtin_weakmap_test.go
@@ -4,6 +4,7 @@ import (
 	"runtime"
 	"testing"
 	"time"
+	"unsafe"
 )
 
 func TestWeakMap(t *testing.T) {
@@ -120,4 +121,84 @@ func TestWeakMapCleanup(t *testing.T) {
 		time.Sleep(10 * time.Millisecond)
 	}
 	t.Fatal("m is not empty")
+}
+
+func TestWeakMapKeyAddressReuse(t *testing.T) {
+	vm := New()
+	val, err := vm.RunString("new WeakMap()")
+	if err != nil {
+		t.Fatal(err)
+	}
+	wmo := val.(*Object).self.(*weakMapObject)
+
+	keyA := vm.NewObject()
+	wmo.m.set(keyA, asciiString("stale"))
+	addrA := uintptr(unsafe.Pointer(keyA))
+
+	wmo.m.Lock()
+	var unlocked bool
+	defer func() {
+		if !unlocked {
+			wmo.m.Unlock()
+		}
+	}()
+
+	keyA = nil
+	runtime.GC()
+
+	var fresh *Object
+	for range 1024 {
+		f := vm.NewObject()
+		if uintptr(unsafe.Pointer(f)) == addrA {
+			fresh = f
+			break
+		}
+	}
+	if fresh == nil {
+		unlocked = true
+		wmo.m.Unlock()
+		t.Skip("allocator did not reuse key address")
+	}
+
+	if v := wmo.m.m[fresh.getId()]; v != nil {
+		unlocked = true
+		wmo.m.Unlock()
+		t.Fatalf("fresh key at recycled address read stale value %v", v)
+	}
+
+	wmo.m.m[fresh.getId()] = asciiString("fresh_value")
+	unlocked = true
+	wmo.m.Unlock()
+
+	for i := 0; i < 50; i++ {
+		runtime.GC()
+		time.Sleep(2 * time.Millisecond)
+	}
+
+	if v := wmo.m.get(fresh); v == nil || v.String() != "fresh_value" {
+		t.Fatalf("live key's entry was prematurely deleted by dead key cleanup: got %v, want fresh_value", v)
+	}
+}
+
+func BenchmarkWeakMapObjectKeyLookup(b *testing.B) {
+	vm := New()
+	v, err := vm.RunString("new WeakMap()")
+	if err != nil {
+		b.Fatal(err)
+	}
+	wmo := v.(*Object).self.(*weakMapObject)
+	keys := make([]*Object, 64)
+	for i := range keys {
+		keys[i] = vm.NewObject()
+		wmo.m.set(keys[i], intToValue(int64(i)))
+	}
+	var s Value
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		for _, k := range keys {
+			s = wmo.m.get(k)
+		}
+	}
+	_ = s
 }

--- a/object.go
+++ b/object.go
@@ -5,7 +5,7 @@ import (
 	"math"
 	"reflect"
 	"sort"
-	"unsafe"
+	"sync/atomic"
 
 	"github.com/dop251/goja/unistring"
 )
@@ -49,6 +49,8 @@ var (
 type Object struct {
 	self    objectImpl
 	runtime *Runtime
+
+	id atomic.Uint64
 }
 
 type iterNextFunc func() (propIterItem, iterNextFunc)
@@ -1623,8 +1625,20 @@ func (o *Object) defineOwnProperty(n Value, desc PropertyDescriptor, throw bool)
 	}
 }
 
+var nextObjectID atomic.Uint64
+
 func (o *Object) getId() uint64 {
-	return uint64(uintptr(unsafe.Pointer(o)))
+	if id := o.id.Load(); id != 0 {
+		return id
+	}
+	id := nextObjectID.Add(1)
+	if id == 0 {
+		id = nextObjectID.Add(1)
+	}
+	if o.id.CompareAndSwap(0, id) {
+		return id
+	}
+	return o.id.Load()
 }
 
 func (o *guardedObject) guard(props ...unistring.String) {

--- a/object_test.go
+++ b/object_test.go
@@ -3,8 +3,12 @@ package goja
 import (
 	"fmt"
 	"reflect"
+	"runtime"
+	"slices"
 	"strings"
+	"sync"
 	"testing"
+	"unsafe"
 )
 
 func TestDefineProperty(t *testing.T) {
@@ -664,5 +668,127 @@ func BenchmarkAddString(b *testing.B) {
 		if !z.StrictEquals(tst) {
 			b.Fatalf("Unexpected result %v", x)
 		}
+	}
+}
+
+func TestObjectID(t *testing.T) {
+	vm := New()
+	o1 := vm.NewObject()
+	id1 := o1.getId()
+	if id1 == 0 {
+		t.Fatal("id is 0")
+	}
+	if id1Again := o1.getId(); id1Again != id1 {
+		t.Fatalf("id changed: %d != %d", id1Again, id1)
+	}
+
+	o2 := vm.NewObject()
+	id2 := o2.getId()
+	if id2 == 0 {
+		t.Fatal("id2 is 0")
+	}
+	if id1 == id2 {
+		t.Fatalf("duplicate id: %d", id1)
+	}
+}
+
+func TestObjectIDConcurrent(t *testing.T) {
+	vm := New()
+	objects := make([]*Object, 8)
+	for i := range objects {
+		objects[i] = vm.NewObject()
+	}
+
+	const goroutines = 8
+	const iterations = 1000
+	results := make([][]uint64, goroutines)
+	var wg sync.WaitGroup
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			res := make([]uint64, len(objects)*iterations)
+			for it := 0; it < iterations; it++ {
+				for i, obj := range objects {
+					res[it*len(objects)+i] = obj.getId()
+				}
+			}
+			results[g] = res
+		}(g)
+	}
+	wg.Wait()
+
+	for i, obj := range objects {
+		expected := results[0][i]
+		if expected == 0 {
+			t.Fatalf("object %d id is 0", i)
+		}
+		for g := 0; g < goroutines; g++ {
+			for it := 0; it < iterations; it++ {
+				if got := results[g][it*len(objects)+i]; got != expected {
+					t.Fatalf("object %d (%p) id mismatch: got %d, want %d", i, obj, got, expected)
+				}
+			}
+		}
+	}
+}
+
+func TestObjectIDNeverReusedAcrossGC(t *testing.T) {
+	vm := New()
+	seenIDs := make(map[uint64]struct{})
+	var seenAddrs []uintptr
+	reusedAddr := false
+
+	for batch := 0; batch < 64; batch++ {
+		ptrs := make([]uintptr, 0, 8)
+		for i := 0; i < 8; i++ {
+			obj := vm.NewObject()
+			ptr := uintptr(unsafe.Pointer(obj))
+			ptrs = append(ptrs, ptr)
+			id := obj.getId()
+			if id == 0 {
+				t.Fatal("id is 0")
+			}
+			if _, exists := seenIDs[id]; exists {
+				t.Fatalf("object ID %d reused after GC", id)
+			}
+			seenIDs[id] = struct{}{}
+		}
+
+		runtime.GC()
+
+		for _, p := range ptrs {
+			if slices.Contains(seenAddrs, p) {
+				reusedAddr = true
+				break
+			}
+		}
+		seenAddrs = append(seenAddrs, ptrs...)
+	}
+
+	if !reusedAddr {
+		t.Skip("allocator did not reuse any heap addresses in this run")
+	}
+}
+
+var benchmarkIDSink uint64
+
+func BenchmarkObjectGetID(b *testing.B) {
+	obj := New().NewObject()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		benchmarkIDSink = obj.getId()
+	}
+}
+
+var benchmarkNewObjectInitIDObjSink *Object
+var benchmarkNewObjectInitIDIDSink uint64
+
+func BenchmarkNewObjectInitID(b *testing.B) {
+	JS := New()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		benchmarkNewObjectInitIDObjSink = JS.NewObject()
+		benchmarkNewObjectInitIDIDSink = benchmarkNewObjectInitIDObjSink.getId()
 	}
 }


### PR DESCRIPTION
### Problem

Commit [2a84ae0](https://github.com/dop251/goja/commit/2a84ae0cf10dd6871a96b3f7e07f8b6881720297) re-implemented `WeakMap` using `runtime.AddCleanup` and derived `Object` identity from its heap address (`uintptr(unsafe.Pointer(o))`) to shrink `Object` from 48 to 24 bytes.

The object's memory is freed during the GC sweep, while the `runtime.AddCleanup` cleanup callback executes asynchronously on background goroutines ([link](https://github.com/golang/go/blob/e3336a22ad3f0a90bd252c95d8b5544e02674205/src/runtime/mcleanup.go#L38-L41)). Because memory is freed before the cleanup runs, the allocator can reuse the dead object's address for a newly allocated `Object`.

When `getId()` returns the heap address, `2a84ae0` behavior may result in these issues, particularly under elevated GC churn:
1. **Stale Reads**: A new object at a recycled address inherits the dead object's ID and reads its WeakMap entry.
2. **Premature Deletion**: The dead object's queued cleanup eventually runs and deletes the *new* object's WeakMap entry.

### Solution
- Add an `id atomic.Uint64` field to `Object`.
- Lazily assign a unique 64-bit ID on the first `getId()` call using an atomic CAS from a package-level counter.

### Tradeoffs
Adding the `id` field increases `Object`'s size from 24 to 32 bytes. This offsets half of the memory savings introduced by `2a84ae0`, but is necessary to ensure identity stability and correctness for `WeakMap` and `WeakSet` under GC churn.

### Performance (darwin-arm64, Apple M2 Pro)
- `BenchmarkObjectGetID`: 0.38 ns/op, 0 allocs.
- `BenchmarkNewObjectInitID`: 108.0 ns/op, 192 B/op, 3 allocs (matches raw `NewObject()` creation cost, no extra allocations).
- `BenchmarkWeakMapObjectKeyLookup`: 619.0 ns/op, 0 allocs.
