### PR TITLE
Salt Object.hash to disperse object hashes relative to sequential integer keys

### DIFF
--- a/builtin_weakmap_test.go
+++ b/builtin_weakmap_test.go
@@ -4,6 +4,7 @@ import (
 	"runtime"
 	"testing"
 	"time"
+	"unsafe"
 )
 
 func TestWeakMap(t *testing.T) {
@@ -120,4 +121,84 @@ func TestWeakMapCleanup(t *testing.T) {
 		time.Sleep(10 * time.Millisecond)
 	}
 	t.Fatal("m is not empty")
+}
+
+func TestWeakMapKeyAddressReuse(t *testing.T) {
+	vm := New()
+	val, err := vm.RunString("new WeakMap()")
+	if err != nil {
+		t.Fatal(err)
+	}
+	wmo := val.(*Object).self.(*weakMapObject)
+
+	keyA := vm.NewObject()
+	wmo.m.set(keyA, asciiString("stale"))
+	addrA := uintptr(unsafe.Pointer(keyA))
+
+	wmo.m.Lock()
+	var unlocked bool
+	defer func() {
+		if !unlocked {
+			wmo.m.Unlock()
+		}
+	}()
+
+	keyA = nil
+	runtime.GC()
+
+	var fresh *Object
+	for range 1024 {
+		f := vm.NewObject()
+		if uintptr(unsafe.Pointer(f)) == addrA {
+			fresh = f
+			break
+		}
+	}
+	if fresh == nil {
+		unlocked = true
+		wmo.m.Unlock()
+		t.Skip("allocator did not reuse key address")
+	}
+
+	if v := wmo.m.m[fresh.getId()]; v != nil {
+		unlocked = true
+		wmo.m.Unlock()
+		t.Fatalf("fresh key at recycled address read stale value %v", v)
+	}
+
+	wmo.m.m[fresh.getId()] = asciiString("fresh_value")
+	unlocked = true
+	wmo.m.Unlock()
+
+	for i := 0; i < 50; i++ {
+		runtime.GC()
+		time.Sleep(2 * time.Millisecond)
+	}
+
+	if v := wmo.m.get(fresh); v == nil || v.String() != "fresh_value" {
+		t.Fatalf("live key's entry was prematurely deleted by dead key cleanup: got %v, want fresh_value", v)
+	}
+}
+
+func BenchmarkWeakMapObjectKeyLookup(b *testing.B) {
+	vm := New()
+	v, err := vm.RunString("new WeakMap()")
+	if err != nil {
+		b.Fatal(err)
+	}
+	wmo := v.(*Object).self.(*weakMapObject)
+	keys := make([]*Object, 64)
+	for i := range keys {
+		keys[i] = vm.NewObject()
+		wmo.m.set(keys[i], intToValue(int64(i)))
+	}
+	var s Value
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		for _, k := range keys {
+			s = wmo.m.get(k)
+		}
+	}
+	_ = s
 }

--- a/map_test.go
+++ b/map_test.go
@@ -199,3 +199,98 @@ func TestOrderedMapIterDeleteCurrent(t *testing.T) {
 		t.Fatalf("2: unexpected key: %v", entry.key)
 	}
 }
+
+func TestObjectHash(t *testing.T) {
+	vm := New()
+	o1 := vm.NewObject()
+	o2 := vm.NewObject()
+
+	var h maphash.Hash
+	if o1.hash(&h) != o1.hash(&h) {
+		t.Fatal("Object.hash is not idempotent")
+	}
+	if o1.hash(nil) != o1.hash(&h) {
+		t.Fatal("Object.hash depends on hasher instance")
+	}
+	if o1.hash(nil) == o1.getId() {
+		t.Fatal("Object.hash must not equal raw getId()")
+	}
+	if o1.hash(nil) == o2.hash(nil) {
+		t.Fatal("distinct objects must have distinct hashes")
+	}
+}
+
+func TestMapMixedKeys(t *testing.T) {
+	m := newOrderedMap(&maphash.Hash{})
+	vm := New()
+	const count = 50
+
+	objects := make([]*Object, count)
+	for i := 0; i < count; i++ {
+		intKey := intToValue(int64(i + 1))
+		objKey := vm.NewObject()
+		objects[i] = objKey
+		m.set(intKey, asciiString(strconv.Itoa(i)))
+		m.set(objKey, asciiString(strconv.Itoa(i)))
+	}
+
+	for i := 0; i < count; i += 2 {
+		if !m.remove(intToValue(int64(i + 1))) {
+			t.Fatalf("failed to remove int key %d", i+1)
+		}
+	}
+
+	for i := 0; i < count; i++ {
+		intKey := intToValue(int64(i + 1))
+		val := m.get(intKey)
+		if i%2 == 0 {
+			if val != nil {
+				t.Fatalf("removed int key %d still present: %v", i+1, val)
+			}
+		} else {
+			if val == nil || !asciiString(strconv.Itoa(i)).SameAs(val) {
+				t.Fatalf("retained int key %d missing or wrong: %v", i+1, val)
+			}
+		}
+
+		objVal := m.get(objects[i])
+		if objVal == nil || !asciiString(strconv.Itoa(i)).SameAs(objVal) {
+			t.Fatalf("object key %d missing or wrong after int removal: %v", i, objVal)
+		}
+	}
+}
+
+var benchmarkHashSink uint64
+
+func BenchmarkObjectHash(b *testing.B) {
+	obj := New().NewObject()
+	var h maphash.Hash
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		benchmarkHashSink = obj.hash(&h)
+	}
+}
+
+func BenchmarkMapMixedKeyLookup(b *testing.B) {
+	vm := New()
+	m := newOrderedMap(vm.getHash())
+	keys := make([]Value, 0, 64)
+	for i := int64(0); i < 32; i++ {
+		iv := valueInt(i)
+		keys = append(keys, iv)
+		m.set(iv, intToValue(i))
+		ov := vm.NewObject()
+		keys = append(keys, ov)
+		m.set(ov, intToValue(i+1000))
+	}
+	var s Value
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		for _, k := range keys {
+			s = m.get(k)
+		}
+	}
+	_ = s
+}

--- a/map_test.go
+++ b/map_test.go
@@ -206,7 +206,9 @@ func TestObjectHash(t *testing.T) {
 	o2 := vm.NewObject()
 
 	var h maphash.Hash
-	if o1.hash(&h) != o1.hash(&h) {
+	a := o1.hash(&h)
+	b := o1.hash(&h)
+	if a != b {
 		t.Fatal("Object.hash is not idempotent")
 	}
 	if o1.hash(nil) != o1.hash(&h) {

--- a/object.go
+++ b/object.go
@@ -5,7 +5,7 @@ import (
 	"math"
 	"reflect"
 	"sort"
-	"unsafe"
+	"sync/atomic"
 
 	"github.com/dop251/goja/unistring"
 )
@@ -49,6 +49,8 @@ var (
 type Object struct {
 	self    objectImpl
 	runtime *Runtime
+
+	id atomic.Uint64
 }
 
 type iterNextFunc func() (propIterItem, iterNextFunc)
@@ -1623,8 +1625,20 @@ func (o *Object) defineOwnProperty(n Value, desc PropertyDescriptor, throw bool)
 	}
 }
 
+var nextObjectID atomic.Uint64
+
 func (o *Object) getId() uint64 {
-	return uint64(uintptr(unsafe.Pointer(o)))
+	if id := o.id.Load(); id != 0 {
+		return id
+	}
+	id := nextObjectID.Add(1)
+	if id == 0 {
+		id = nextObjectID.Add(1)
+	}
+	if o.id.CompareAndSwap(0, id) {
+		return id
+	}
+	return o.id.Load()
 }
 
 func (o *guardedObject) guard(props ...unistring.String) {

--- a/object_test.go
+++ b/object_test.go
@@ -3,8 +3,12 @@ package goja
 import (
 	"fmt"
 	"reflect"
+	"runtime"
+	"slices"
 	"strings"
+	"sync"
 	"testing"
+	"unsafe"
 )
 
 func TestDefineProperty(t *testing.T) {
@@ -664,5 +668,127 @@ func BenchmarkAddString(b *testing.B) {
 		if !z.StrictEquals(tst) {
 			b.Fatalf("Unexpected result %v", x)
 		}
+	}
+}
+
+func TestObjectID(t *testing.T) {
+	vm := New()
+	o1 := vm.NewObject()
+	id1 := o1.getId()
+	if id1 == 0 {
+		t.Fatal("id is 0")
+	}
+	if id1Again := o1.getId(); id1Again != id1 {
+		t.Fatalf("id changed: %d != %d", id1Again, id1)
+	}
+
+	o2 := vm.NewObject()
+	id2 := o2.getId()
+	if id2 == 0 {
+		t.Fatal("id2 is 0")
+	}
+	if id1 == id2 {
+		t.Fatalf("duplicate id: %d", id1)
+	}
+}
+
+func TestObjectIDConcurrent(t *testing.T) {
+	vm := New()
+	objects := make([]*Object, 8)
+	for i := range objects {
+		objects[i] = vm.NewObject()
+	}
+
+	const goroutines = 8
+	const iterations = 1000
+	results := make([][]uint64, goroutines)
+	var wg sync.WaitGroup
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			res := make([]uint64, len(objects)*iterations)
+			for it := 0; it < iterations; it++ {
+				for i, obj := range objects {
+					res[it*len(objects)+i] = obj.getId()
+				}
+			}
+			results[g] = res
+		}(g)
+	}
+	wg.Wait()
+
+	for i, obj := range objects {
+		expected := results[0][i]
+		if expected == 0 {
+			t.Fatalf("object %d id is 0", i)
+		}
+		for g := 0; g < goroutines; g++ {
+			for it := 0; it < iterations; it++ {
+				if got := results[g][it*len(objects)+i]; got != expected {
+					t.Fatalf("object %d (%p) id mismatch: got %d, want %d", i, obj, got, expected)
+				}
+			}
+		}
+	}
+}
+
+func TestObjectIDNeverReusedAcrossGC(t *testing.T) {
+	vm := New()
+	seenIDs := make(map[uint64]struct{})
+	var seenAddrs []uintptr
+	reusedAddr := false
+
+	for batch := 0; batch < 64; batch++ {
+		ptrs := make([]uintptr, 0, 8)
+		for i := 0; i < 8; i++ {
+			obj := vm.NewObject()
+			ptr := uintptr(unsafe.Pointer(obj))
+			ptrs = append(ptrs, ptr)
+			id := obj.getId()
+			if id == 0 {
+				t.Fatal("id is 0")
+			}
+			if _, exists := seenIDs[id]; exists {
+				t.Fatalf("object ID %d reused after GC", id)
+			}
+			seenIDs[id] = struct{}{}
+		}
+
+		runtime.GC()
+
+		for _, p := range ptrs {
+			if slices.Contains(seenAddrs, p) {
+				reusedAddr = true
+				break
+			}
+		}
+		seenAddrs = append(seenAddrs, ptrs...)
+	}
+
+	if !reusedAddr {
+		t.Skip("allocator did not reuse any heap addresses in this run")
+	}
+}
+
+var benchmarkIDSink uint64
+
+func BenchmarkObjectGetID(b *testing.B) {
+	obj := New().NewObject()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		benchmarkIDSink = obj.getId()
+	}
+}
+
+var benchmarkNewObjectInitIDObjSink *Object
+var benchmarkNewObjectInitIDIDSink uint64
+
+func BenchmarkNewObjectInitID(b *testing.B) {
+	JS := New()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		benchmarkNewObjectInitIDObjSink = JS.NewObject()
+		benchmarkNewObjectInitIDIDSink = benchmarkNewObjectInitIDObjSink.getId()
 	}
 }

--- a/value.go
+++ b/value.go
@@ -17,10 +17,11 @@ var (
 	// Not goroutine-safe, do not use for anything other than package level init
 	pkgHasher maphash.Hash
 
-	hashFalse = randomHash()
-	hashTrue  = randomHash()
-	hashNull  = randomHash()
-	hashUndef = randomHash()
+	hashFalse      = randomHash()
+	hashTrue       = randomHash()
+	hashNull       = randomHash()
+	hashUndef      = randomHash()
+	hashObjectSalt = randomHash()
 )
 
 // Not goroutine-safe, do not use for anything other than package level init
@@ -798,7 +799,7 @@ func (o *Object) ExportType() reflect.Type {
 }
 
 func (o *Object) hash(*maphash.Hash) uint64 {
-	return o.getId()
+	return o.getId() ^ hashObjectSalt
 }
 
 // Get an object's property by name.


### PR DESCRIPTION
N.B. Dependent on #725

### Problem
In `goja/value.go`, `Object.hash(*maphash.Hash)` returned `o.getId()` directly.

Because `valueInt.hash` returns its integer value directly (`uint64(i)`), sequential Object IDs (1, 2, 3...) systematically collided with equal-valued integer keys (1, 2, 3...) in mixed `Map` and `Set` collections.

### Solution
Salt `Object.hash` with a package-level random constant (`hashObjectSalt = randomHash()`), returning `o.getId() ^ hashObjectSalt`.

This matches the existing convention used in `goja/value.go` for fixed-width primitive types (`valueBool`, `valueNull`, `valueUndefined`), which use package-level random constants initialized via `pkgHasher`.

### Performance (darwin-arm64, Apple M2 Pro)
```
BenchmarkObjectHash-10         1000000000          0.4966 ns/op          0 B/op          0 allocs/op
BenchmarkMapMixedKeyLookup-10     2032828          590.6 ns/op           0 B/op          0 allocs/op
```
