### PR TITLE
Fix tc39 tests on Windows

### DIFF
--- a/.tc39_test262_checkout.sh
+++ b/.tc39_test262_checkout.sh
@@ -5,6 +5,7 @@ sha=3af36bec45bd4f72d4b57366653578e1e4dafef7
 mkdir -p testdata/test262
 cd testdata/test262
 git init
+git config core.autocrlf false
 git remote add origin https://github.com/tc39/test262.git
 git fetch origin --depth=1 "${sha}"
 git reset --hard "${sha}"


### PR DESCRIPTION
Windows's default git installation enables `core.autocrlf` git option by default, which means all text files are checked out with `\r\n` line endings instead of what is commited in the repository. This behavior breaks one of the tc39 tests as it expects `\n` in the source file.
```
--- FAIL: TestTC39 (7.58s)
    --- FAIL: TestTC39/tc39 (0.61s)
        --- FAIL: TestTC39/tc39/test/built-ins/Function/prototype/toString/line-terminator-normalisation-LF.js (0.00s)
            tc39_test.go:715: Running normal test: test/built-ins/Function/prototype/toString/line-terminator-normalisation-LF.js
            tc39_test.go:612: test/built-ins/Function/prototype/toString/line-terminator-normalisation-LF.js: Test262Error: Conforms to NativeFunction Syntax: "function\r\n// a\r\nf\r\n// b\r\n(\r\n// c\r\nx\r\n// d\r\n,\r\n// e\r\ny\r\n// f\r\n)\r\n// g\r\n{\r\n// h\r\n;\r\n// i\r\n;\r\n// j\r\n}" (function
                // a
                f
                // b
                (
                // c
                x
                // d
                ,
                // e
                y
                // f
                )
                // g
                {
                // h
                ;
                // i
                ;
                // j
                }) at assertNativeFunction (harness/nativeFunctionMatcher.js:218:5(30))
FAIL
exit status 1
FAIL    github.com/dop251/goja  8.527s
```

The change is to modify `.tc39_test262_checkout.sh` script and explicitly disable line ending conversion.