### PR TITLE
Treat '-' next to a character class escape as a literal. Fixes #698.

### DIFF
--- a/parser/regexp.go
+++ b/parser/regexp.go
@@ -255,21 +255,59 @@ func (self *_RegExp_parser) scanBracket() {
 	}
 
 	self.pass()
-	for self.chr != -1 {
-		if self.chr == ']' {
-			break
-		} else if self.chr == '\\' {
-			self.read()
-			self.scanEscape(true)
+	if self.chr == '^' {
+		self.pass()
+	}
+	for self.chr != -1 && self.chr != ']' {
+		leftIsClass := self.scanClassAtom()
+		if self.unicode || self.chr != '-' {
 			continue
 		}
-		self.pass()
+		if self.offset >= self.length || self.str[self.offset] == ']' {
+			continue
+		}
+		if leftIsClass || self.nextIsCharacterClassEscape() {
+			// A '-' next to a class escape is a literal, not a range operator.
+			self.writeString(`\-`)
+			self.read()
+		} else {
+			self.pass()
+		}
+		self.scanClassAtom()
 	}
 	if self.chr != ']' {
 		self.error(true, "Unterminated character class")
 		return
 	}
 	self.pass()
+}
+
+// scanClassAtom writes a single class atom and reports whether it stands for more than one character.
+func (self *_RegExp_parser) scanClassAtom() bool {
+	if self.chr == '\\' {
+		self.read()
+		isClass := isCharacterClassEscape(self.chr)
+		self.scanEscape(true)
+		return isClass
+	}
+	if self.chr == '-' && !self.unicode {
+		// A '-' in atom position is a literal; escape it so re2 cannot pair it with the next atom.
+		self.writeString(`\-`)
+		self.read()
+		return false
+	}
+	self.pass()
+	return false
+}
+
+// isCharacterClassEscape reports whether c is a class escape standing for more than one character.
+func isCharacterClassEscape(c rune) bool {
+	return c == 'd' || c == 'D' || c == 's' || c == 'S' || c == 'w' || c == 'W'
+}
+
+// nextIsCharacterClassEscape reports whether the input after the current character is a class escape.
+func (self *_RegExp_parser) nextIsCharacterClassEscape() bool {
+	return self.offset+1 < self.length && self.str[self.offset] == '\\' && isCharacterClassEscape(rune(self.str[self.offset+1]))
 }
 
 // \...

--- a/parser/regexp_test.go
+++ b/parser/regexp_test.go
@@ -143,6 +143,33 @@ func TestRegExp(t *testing.T) {
 
 			test(`\S+`, "[^"+WhitespaceChars+"]+")
 
+			// A '-' next to a class escape is a literal, not a range operator.
+			test(`[\s-_]`, "["+WhitespaceChars+`\-_]`)
+
+			test(`[\d-_]`, `[\d\-_]`)
+
+			test(`[\w-_]`, `[\w\-_]`)
+
+			test(`[\D-_]`, `[\D\-_]`)
+
+			test(`[\W-_]`, `[\W\-_]`)
+
+			test(`[_-\s]`, "[_"+`\-`+WhitespaceChars+"]")
+
+			test(`[_-\d]`, `[_\-\d]`)
+
+			test(`[\s-\d]`, "["+WhitespaceChars+`\-\d]`)
+
+			// A class escape standing for a single character keeps the range.
+			test(`[\b-_]`, `[\x08-_]`)
+
+			// The atom after a completed range cannot start a new one, so its '-' stays literal.
+			test(`[\s-_-a]`, "["+WhitespaceChars+`\-_\-a]`)
+
+			test(`[-]`, `[\-]`)
+
+			test(`[a-z-]`, `[a-z\-]`)
+
 		}
 	})
 }

--- a/regexp_test.go
+++ b/regexp_test.go
@@ -158,6 +158,32 @@ func TestRegexpSInClass(t *testing.T) {
 	testScript(SCRIPT, valueFalse, t)
 }
 
+func TestRegexpDashAfterClassEscape(t *testing.T) {
+	const SCRIPT = `
+	var toCamelCase = function(s) {
+		return s.replace(/^([A-Z])|[\s-_]+(\w)/g, function(m, p1, p2) {
+			return p2 ? p2.toUpperCase() : p1.toLowerCase();
+		});
+	};
+	toCamelCase("Foo bar-baz_qux");
+	`
+
+	testScript(SCRIPT, asciiString("fooBarBazQux"), t)
+}
+
+func TestRegexpDashNextToClassEscape(t *testing.T) {
+	const SCRIPT = `
+	/^[\s-_]$/.test("-") && /^[\s-_]$/.test("_") && /^[\s-_]$/.test(" ") && !/^[\s-_]$/.test("a") &&
+	/^[_-\s]$/.test("-") && /^[\s-\d]$/.test("-") && /^[\d-_]$/.test("-") &&
+	/^[a-z]$/.test("m") && !/^[a-z]$/.test("-") &&
+	/^[\s\-_]$/.test("-") && /^[\s\-_]$/.test(" ") &&
+	/^[\b-_]$/.test("Z") && !/^[\b-_]$/.test("a") &&
+	/^[\s-_-a]$/.test("a") && !/^[\s-_-a]$/.test("\u0060");
+	`
+
+	testScript(SCRIPT, valueTrue, t)
+}
+
 func TestRegexpDotMatchCR(t *testing.T) {
 	const SCRIPT = `
 	/./.test("\r");


### PR DESCRIPTION
Fixes #698.

Per Annex B (`CharacterRangeOrUnion`), in non-Unicode patterns a `-` is a literal rather than a range operator when either side is a class escape matching more than one character. `[\s-_]` is therefore valid JavaScript, but the transformer passed the `-` straight through and re2 rejected the result:

```
SyntaxError: Invalid regular expression (re2): ^([A-Z])|[...﻿-_]+(\w)
(error parsing regexp: invalid character class range: `﻿-_`)
```

`scanBracket` now walks the class one production at a time (`scanClassAtom`) and escapes the `-` when either operand is `\d \D \s \S \w \W`.

Escaping a `-` in atom position matters too, and this is the part worth reviewing: without it, a completed range leaves its right operand free for re2 to re-pair. `[\s-_-a]` would then compile to something matching U+0060 — where master currently errors. A narrower patch that only escaped the dash between the two operands passed 26 of 27 patterns I tried and turned that loud error into a silent wrong match, which is why the class loop is a state machine rather than a substitution.

Genuine ranges are unaffected: `[a-z]`, `[G-b]` and `[\b-_]` keep range semantics — `\b` inside a class is U+0008, a single character — and `[\s\-_]` is unchanged. Unicode mode is untouched, where the pattern is still correctly a `SyntaxError`, matching Node.

Scope turned out narrower than the issue suggests: `[\d-_]`, `[\w-_]`, `[\D-_]` and `[\W-_]` already worked, because re2 happens to agree there. Only `\s` (which goja expands to a raw character list ending `﻿`) and any `-` *preceding* a class escape were broken.

## Tests

This enables two vendored tc39 tests that currently fail:

```
annexB/language/literals/regexp/non-empty-class-ranges-no-dash.js   FAIL -> PASS
annexB/language/literals/regexp/non-empty-class-ranges.js           FAIL -> PASS
```

That directory is not registered in `tc39_test.go` — it runs `test/annexB/built-ins/RegExp` but not `test/annexB/language/literals/regexp` — which is presumably why this went unnoticed. I have not wired the directory in here, since doing so would also surface two unrelated pre-existing Annex B failures (`class-escape.js`, `legacy-octal-escape.js`).

Beyond compilation I diffed character-set membership against Node over 67 patterns x 29 characters: 67/67 exact match, including `[\s-_-a]`, `[\d-a-b]`, `[a-\s-b]`, `[---]` and `[^-\s]`.

## Against the contribution checklist

- **ECMA standard**: clause quoted above; the two test262 files for it now pass.
- **Performance**: benchstat over 10 runs shows no significant difference on any benchmark (p = 0.143 / 0.079 / 0.697), geomean -1.45%, allocations identical.
- **tc39**: 31,649 pass / 0 fail, before and after, with byte-identical test-name sets.

`gofmt -d .`, `go vet ./...`, staticcheck 2026.2 and `go test -vet=off ./...` are clean on both amd64 and `GOARCH=386`, mirroring `.github/workflows/main.yml`.

## On the bigger question

You mentioned possibly moving to regexp2 wholesale rather than growing the transformer further. This is deliberately the smaller "current situation" fix you described, contained to `scanBracket`, so it is cheap to drop if the regexp2 direction goes ahead. It has no textual overlap with #715, and #678 would replace `parser/regexp.go` entirely.

Credit to @zbysir for the report and the reproduction.

Disclosure: I use AI assistance in my work, and I review and verify everything before it goes out. The Node comparison and the red-green runs above are my own.
