### PR TITLE
Fix a bunch of skipped tc39 tests

### DIFF
--- a/builtin_array.go
+++ b/builtin_array.go
@@ -1194,8 +1194,8 @@ func (r *Runtime) arrayproto_flat(call FunctionCall) Value {
 	o := call.This.ToObject(r)
 	l := toLength(o.self.getStr("length", nil))
 	depthNum := int64(1)
-	if len(call.Arguments) > 0 {
-		depthNum = call.Argument(0).ToInteger()
+	if arg := call.Argument(0); arg != _undefined {
+		depthNum = arg.ToInteger()
 	}
 	a := arraySpeciesCreate(o, 0)
 	r.flattenIntoArray(a, o, l, 0, depthNum, nil, nil)

--- a/builtin_error.go
+++ b/builtin_error.go
@@ -1,6 +1,8 @@
 package goja
 
-import "github.com/dop251/goja/unistring"
+import (
+	"github.com/dop251/goja/unistring"
+)
 
 const propNameStack = "stack"
 
@@ -122,7 +124,7 @@ func (r *Runtime) newErrorObject(proto *Object, class string) *errorObject {
 func (r *Runtime) builtin_Error(args []Value, proto *Object) *Object {
 	obj := r.newErrorObject(proto, classError)
 	if len(args) > 0 && args[0] != _undefined {
-		obj._putProp("message", args[0].ToString(), true, false, true)
+		obj._putProp("message", args[0].toString(), true, false, true)
 	}
 	if len(args) > 1 && args[1] != _undefined {
 		if options, ok := args[1].(*Object); ok {
@@ -164,6 +166,15 @@ func (r *Runtime) builtin_AggregateError(args []Value, proto *Object) *Object {
 	}
 
 	return obj.val
+}
+
+func (r *Runtime) error_isError(call FunctionCall) Value {
+	if o, ok := call.Argument(0).(*Object); ok {
+		if o.self.className() == classError {
+			return valueTrue
+		}
+	}
+	return valueFalse
 }
 
 func writeErrorString(sb *StringBuilder, obj *Object) String {
@@ -229,6 +240,8 @@ func (r *Runtime) getError() *Object {
 		ret = &Object{runtime: r}
 		r.global.Error = ret
 		r.newNativeFuncConstruct(ret, r.builtin_Error, "Error", r.getErrorPrototype(), 1)
+		o := ret.self
+		o._putProp("isError", r.newNativeFunc(r.error_isError, "isError", 1), true, false, true)
 	}
 	return ret
 }

--- a/builtin_error.go
+++ b/builtin_error.go
@@ -146,10 +146,11 @@ func (r *Runtime) builtin_AggregateError(args []Value, proto *Object) *Object {
 	if len(args) > 1 && args[1] != nil && args[1] != _undefined {
 		obj._putProp("message", args[1].toString(), true, false, true)
 	}
-	var errors []Value
+	items := _undefined
 	if len(args) > 0 {
-		errors = r.iterableToList(args[0], nil)
+		items = args[0]
 	}
+	errors := r.iterableToList(items, nil)
 	obj._putProp("errors", r.newArrayValues(errors), true, false, true)
 
 	if len(args) > 2 && args[2] != _undefined {
@@ -165,6 +166,13 @@ func (r *Runtime) builtin_AggregateError(args []Value, proto *Object) *Object {
 		}
 	}
 
+	return obj.val
+}
+
+func (r *Runtime) newAggregateErrorErrors(errors []Value) *Object {
+	proto := r.getPrototypeFromCtor(r.getAggregateError(), nil, nil)
+	obj := r.newErrorObject(proto, classError)
+	obj._putProp("errors", r.newArrayValues(errors), true, false, true)
 	return obj.val
 }
 

--- a/builtin_json.go
+++ b/builtin_json.go
@@ -364,6 +364,10 @@ func (ctx *_builtinJSON_stringifyContext) str(key Value, holder *Object) bool {
 	case *valueBigInt:
 		ctx.r.typeErrorResult(true, "Do not know how to serialize a BigInt")
 	case *Object:
+		if value1.self.className() == classRawJSON {
+			ctx.buf.WriteString(value1.self.getStr("rawJSON", nil).String())
+			return true
+		}
 		for _, object := range ctx.stack {
 			if value1.SameAs(object) {
 				ctx.r.typeErrorResult(true, "Converting circular structure to JSON")
@@ -528,6 +532,50 @@ func (ctx *_builtinJSON_stringifyContext) quote(str String) {
 	ctx.buf.WriteByte('"')
 }
 
+func (r *Runtime) builtinJSON_rawJSON(call FunctionCall) Value {
+	arg := call.Argument(0)
+
+	var jsonString String
+	switch dd := arg.(type) {
+	case String:
+		jsonString = dd
+		if jsonString.Length() == 0 {
+			panic(r.newSyntaxError("\"\" is unacceptable as raw JSON", 0))
+		}
+		first := jsonString.CharAt(0)
+		last := jsonString.CharAt(jsonString.Length() - 1)
+		if first == '{' || first == '[' ||
+			first == ' ' || first == '\n' || first == '\r' || first == '\t' ||
+			last == ' ' || last == '\n' || last == '\r' || last == '\t' {
+			panic(r.newSyntaxError("\""+arg.String()+"\" is unacceptable as raw JSON", 0))
+		}
+		if !json.Valid([]byte(jsonString.String())) {
+			panic(r.newSyntaxError("\""+arg.String()+"\" is not a valid JSON", 0))
+		}
+	case valueBool, valueInt, *valueBigInt, valueFloat, valueNull:
+		jsonString = dd.toString()
+	case *Symbol:
+		panic(r.NewTypeError("Cannot convert a Symbol value to a string"))
+	default:
+		panic(r.newSyntaxError(arg.String()+" is not a valid JSON", 0))
+	}
+
+	o := r.newBaseObject(nil, classRawJSON)
+	o._putProp("rawJSON", jsonString, false, true, false)
+	o.preventExtensions(true)
+	return o.val
+}
+
+func (r *Runtime) builtinJSON_isRawJSON(call FunctionCall) Value {
+	arg := call.Argument(0)
+	if o, ok := arg.(*Object); ok {
+		if o.self.className() == classRawJSON {
+			return valueTrue
+		}
+	}
+	return valueFalse
+}
+
 func (r *Runtime) getJSON() *Object {
 	ret := r.global.JSON
 	if ret == nil {
@@ -536,6 +584,8 @@ func (r *Runtime) getJSON() *Object {
 		r.global.JSON = ret
 		JSON._putProp("parse", r.newNativeFunc(r.builtinJSON_parse, "parse", 2), true, false, true)
 		JSON._putProp("stringify", r.newNativeFunc(r.builtinJSON_stringify, "stringify", 3), true, false, true)
+		JSON._putProp("rawJSON", r.newNativeFunc(r.builtinJSON_rawJSON, "rawJSON", 1), true, false, true)
+		JSON._putProp("isRawJSON", r.newNativeFunc(r.builtinJSON_isRawJSON, "isRawJSON", 1), true, false, true)
 		JSON._putSym(SymToStringTag, valueProp(asciiString(classJSON), false, false, true))
 	}
 	return ret

--- a/builtin_promise.go
+++ b/builtin_promise.go
@@ -1,8 +1,9 @@
 package goja
 
 import (
-	"github.com/dop251/goja/unistring"
 	"reflect"
+
+	"github.com/dop251/goja/unistring"
 )
 
 type PromiseState int
@@ -502,9 +503,7 @@ func (r *Runtime) promise_any(call FunctionCall) Value {
 				errors[index] = call.Argument(0)
 				remainingElementsCount--
 				if remainingElementsCount == 0 {
-					_error := r.builtin_new(r.getAggregateError(), nil)
-					_error.self._putProp("errors", r.newArrayValues(errors), true, false, true)
-					pcap.reject(_error)
+					pcap.reject(r.newAggregateErrorErrors(errors))
 				}
 				return _undefined
 			}, "", 1)
@@ -514,9 +513,7 @@ func (r *Runtime) promise_any(call FunctionCall) Value {
 		})
 		remainingElementsCount--
 		if remainingElementsCount == 0 {
-			_error := r.builtin_new(r.getAggregateError(), nil)
-			_error.self._putProp("errors", r.newArrayValues(errors), true, false, true)
-			pcap.reject(_error)
+			pcap.reject(r.newAggregateErrorErrors(errors))
 		}
 	})
 	return pcap.promise

--- a/object.go
+++ b/object.go
@@ -26,6 +26,7 @@ const (
 	classRegExp        = "RegExp"
 	classDate          = "Date"
 	classJSON          = "JSON"
+	classRawJSON       = "RawJSON"
 	classGlobal        = "global"
 	classPromise       = "Promise"
 

--- a/object.go
+++ b/object.go
@@ -453,6 +453,12 @@ func (o *baseObject) setProto(proto *Object, throw bool) bool {
 	if current.SameAs(proto) {
 		return true
 	}
+	// 10.4.7 Immutable Prototype Exotic Objects
+	// Object.prototype seems like the only immutable prototype exotic object
+	if o.val == o.val.runtime.global.ObjectPrototype {
+		o.val.runtime.typeErrorResult(throw, "Immutable prototype object 'Object.prototype' cannot have their prototype set")
+		return false
+	}
 	if !o.extensible {
 		o.val.runtime.typeErrorResult(throw, "%s is not extensible", o.val)
 		return false

--- a/tc39_test.go
+++ b/tc39_test.go
@@ -217,9 +217,6 @@ var (
 		"test/built-ins/JSON/parse/reviver-context-source-array-literal.js":         true,
 		"test/built-ins/JSON/parse/reviver-call-args-after-forward-modification.js": true,
 
-		// AggregateError
-		"test/built-ins/AggregateError/errors-iterabletolist.js": true,
-
 		// Language tests (class, with, module, expressions, identifiers)
 		"test/language/statements/class/subclass/private-class-field-on-nonextensible-return-override.js":                                   true,
 		"test/language/statements/class/elements/syntax/valid/grammar-field-named-set-followed-by-generator-asi.js":                         true,

--- a/tc39_test.go
+++ b/tc39_test.go
@@ -217,11 +217,9 @@ var (
 		"test/built-ins/JSON/parse/reviver-context-source-array-literal.js":         true,
 		"test/built-ins/JSON/parse/reviver-call-args-after-forward-modification.js": true,
 
-		// Object, Array, AggregateError
-		"test/built-ins/Object/prototype/setPrototypeOf-with-non-circular-values.js":           true,
-		"test/built-ins/Object/prototype/setPrototypeOf-with-non-circular-values-__proto__.js": true,
-		"test/built-ins/Array/prototype/flat/non-numeric-depth-should-not-throw.js":            true,
-		"test/built-ins/AggregateError/errors-iterabletolist.js":                               true,
+		// Array, AggregateError
+		"test/built-ins/Array/prototype/flat/non-numeric-depth-should-not-throw.js": true,
+		"test/built-ins/AggregateError/errors-iterabletolist.js":                    true,
 
 		// Language tests (class, with, module, expressions, identifiers)
 		"test/language/statements/class/subclass/private-class-field-on-nonextensible-return-override.js":                                   true,

--- a/tc39_test.go
+++ b/tc39_test.go
@@ -217,20 +217,6 @@ var (
 		"test/built-ins/JSON/parse/reviver-context-source-array-literal.js":         true,
 		"test/built-ins/JSON/parse/reviver-call-args-after-forward-modification.js": true,
 
-		// Error.isError
-		"test/built-ins/Error/isError/symbols.js":                                   true,
-		"test/built-ins/Error/isError/primitives.js":                                true,
-		"test/built-ins/Error/isError/prop-desc.js":                                 true,
-		"test/built-ins/Error/isError/name.js":                                      true,
-		"test/built-ins/Error/isError/is-a-constructor.js":                          true,
-		"test/built-ins/Error/isError/fake-errors.js":                               true,
-		"test/built-ins/Error/isError/errors.js":                                    true,
-		"test/built-ins/Error/isError/non-error-objects.js":                         true,
-		"test/built-ins/Error/isError/error-subclass.js":                            true,
-		"test/built-ins/Error/isError/bigints.js":                                   true,
-		"test/built-ins/Error/error-message-tostring-symbol.js":                     true,
-		"test/built-ins/NativeErrors/nativeerror-tostring-message-throws-symbol.js": true,
-
 		// Object, Array, AggregateError
 		"test/built-ins/Object/prototype/setPrototypeOf-with-non-circular-values.js":           true,
 		"test/built-ins/Object/prototype/setPrototypeOf-with-non-circular-values-__proto__.js": true,

--- a/tc39_test.go
+++ b/tc39_test.go
@@ -204,13 +204,8 @@ var (
 		"test/built-ins/RegExp/CharacterClassEscapes/character-class-digit-class-escape-negative-cases.js":          true,
 		"test/built-ins/RegExp/CharacterClassEscapes/character-class-non-whitespace-class-escape-positive-cases.js": true,
 
-		// JSON (rawJSON, reviver)
-		"test/built-ins/JSON/isRawJSON/not-a-constructor.js":                        true,
-		"test/built-ins/JSON/isRawJSON/length.js":                                   true,
-		"test/built-ins/JSON/isRawJSON/prop-desc.js":                                true,
-		"test/built-ins/JSON/isRawJSON/basic.js":                                    true,
-		"test/built-ins/JSON/isRawJSON/name.js":                                     true,
-		"test/built-ins/JSON/isRawJSON/builtin.js":                                  true,
+		// JSON (reviver)
+		"test/built-ins/JSON/rawJSON/bigint-raw-json-can-be-stringified.js":         true,
 		"test/built-ins/JSON/parse/reviver-forward-modifies-object.js":              true,
 		"test/built-ins/JSON/parse/reviver-context-source-primitive-literal.js":     true,
 		"test/built-ins/JSON/parse/reviver-context-source-object-literal.js":        true,
@@ -412,9 +407,6 @@ func init() {
 		// Map getOrInsert*
 		"test/built-ins/WeakMap/prototype/getOrInsert",
 		"test/built-ins/Map/prototype/getOrInsert",
-
-		// rawJSON isn not supported
-		"test/built-ins/JSON/rawJSON",
 	)
 
 }

--- a/tc39_test.go
+++ b/tc39_test.go
@@ -217,9 +217,8 @@ var (
 		"test/built-ins/JSON/parse/reviver-context-source-array-literal.js":         true,
 		"test/built-ins/JSON/parse/reviver-call-args-after-forward-modification.js": true,
 
-		// Array, AggregateError
-		"test/built-ins/Array/prototype/flat/non-numeric-depth-should-not-throw.js": true,
-		"test/built-ins/AggregateError/errors-iterabletolist.js":                    true,
+		// AggregateError
+		"test/built-ins/AggregateError/errors-iterabletolist.js": true,
 
 		// Language tests (class, with, module, expressions, identifiers)
 		"test/language/statements/class/subclass/private-class-field-on-nonextensible-return-override.js":                                   true,


### PR DESCRIPTION
Implemented: 
- `Error.isError`
- `JSON.rawJson`
- `JSON.isRawJSON`

Fixed other tests:
- `test/built-ins/Error/error-message-tostring-symbol.js`
- `test/built-ins/NativeErrors/nativeerror-tostring-message-throws-symbol.js`
- `test/built-ins/Object/prototype/setPrototypeOf-with-non-circular-values.js`
- `test/built-ins/Object/prototype/setPrototypeOf-with-non-circular-values-__proto__.js`
- `test/built-ins/Array/prototype/flat/non-numeric-depth-should-not-throw.js`
- `test/built-ins/AggregateError/errors-iterabletolist.js`

The only thing I am not sure about is `AggregateError` change. The test `errors-iterabletolist.js` verifies that calling `new AggregateError()` should throw an error if the first argument is undefined. `Promise.any` was using this behavior to avoid extra allocation of js array. I used a somewhat hacky method to preserve this optimization.