### PR TITLE
Reset vm.args before running class field initialisers

### DIFF
--- a/compiler_test.go
+++ b/compiler_test.go
@@ -4974,6 +4974,53 @@ func TestClassDynCaptureThisInStaticFieldInit(t *testing.T) {
 	testScript(SCRIPT, valueTrue, t)
 }
 
+func TestClassCaptureThisInFieldInitInsideFunc(t *testing.T) {
+	const SCRIPT = `
+	class C {
+		a = () => this
+	}
+
+	function f(x, y) {
+		let c = new C();
+		return c.a() === c;
+	}
+	f({}, {});
+	`
+	testScript(SCRIPT, valueTrue, t)
+}
+
+func TestClassCapturePrivateThisInFieldInitInsideFunc(t *testing.T) {
+	const SCRIPT = `
+	class C {
+		#a = () => this;
+		get a() {
+			return this.#a();
+		}
+	}
+
+	function f(x, y) {
+		let c = new C();
+		return c.a === c;
+	}
+	f({}, {});
+	`
+	testScript(SCRIPT, valueTrue, t)
+}
+
+func TestClassCaptureThisInStaticFieldInitInsideFunc(t *testing.T) {
+	const SCRIPT = `
+	function f(x, y) {
+		let capture;
+		class C {
+			static #a = (capture = () => this, 0)
+		}
+		return capture() === C;
+	}
+	f({}, {});
+	`
+	testScript(SCRIPT, valueTrue, t)
+}
+
 func TestCompileClass(t *testing.T) {
 	const SCRIPT = `
 	class C extends Error {

--- a/func.go
+++ b/func.go
@@ -330,6 +330,9 @@ func (f *classFuncObject) _initFields(instance *Object) {
 		vm.stash = f.stash
 		vm.privEnv = f.privEnv
 		vm.newTarget = nil
+		// enterFunc derives the stack base from vm.args, which otherwise still
+		// holds the argument count of whichever function is executing 'new'.
+		vm.args = 0
 
 		// so that 'super' base could be correctly resolved (including from direct eval())
 		vm.push(f.val)


### PR DESCRIPTION
A class field initialiser that captures `this` fails when the class is constructed from inside a function that has parameters:

```js
class C {
	#a = () => this;
	get a() { return this.#a(); }
}
function f(x, y) { return new C().a; }
f({}, {}); // panic: interface conversion: goja.objectImpl is *goja.baseObject, not *goja.classFuncObject
```

Public fields fail the same way, with `TypeError: Value is not an Object at <instance_members_initializer>`, and so do static fields of a class declared inside such a function. Which of the two you get depends on what is on the stack.

`_initFields` pushes a fresh context but leaves `vm.args` as it was, i.e. the argument count of whichever function is executing `new`. When the initialiser captures `this`, `compileFieldsAndStaticBlocks` gives it an `enterFunc` prologue, and `enterFunc` computes `vm.sb = sp - vm.args - 1`, so the stack base moves down by that count. `definePrivateProp` then reads `vm.stack[vm.sb-1]` expecting the class function and finds something else. The existing tests (`TestClassCaptureThisInFieldInit` etc.) construct at the top level, where `vm.args` happens to be 0.

The fix sets `vm.args = 0` in `_initFields`. Field initialisers and static blocks cannot reference `arguments`, so zero is the only correct value, and instance fields, static elements and the `super()` path all go through this one function. Three regression tests cover a public field, a private field and a static private field constructed from inside a function with parameters. All three fail without the change, and the full test suite passes with it.

We hit this rendering Svelte 5 components server-side: Svelte compiles a class-field `$derived` to a private field whose initialiser is an arrow capturing `this`, and components are functions with parameters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)